### PR TITLE
BUGFIX: read rempty files

### DIFF
--- a/main/lib/src/FileSerializer.cc
+++ b/main/lib/src/FileSerializer.cc
@@ -45,6 +45,18 @@ namespace eudaq {
   {
     m_file = fopen(fname.c_str(), "rb");
     if (!m_file) EUDAQ_THROWX(FileNotFoundException, "Unable to open file: " + fname);
+    // check if the file actually contains data. otherwise it will hang
+    // later on while trying to sync the events
+    if (fseek(m_file, 0L, SEEK_END) != 0) {
+        EUDAQ_THROWX(FileReadException, "seek to end failed: " + fname);
+    }
+    if (ftell(m_file) == 0) {
+        EUDAQ_THROWX(FileReadException, "file is empty: " + fname);
+    }
+    // go back to the beginning of the file
+    if (fseek(m_file, 0L, SEEK_SET) != 0) {
+        EUDAQ_THROWX(FileReadException, "seek to begin failed: " + fname);
+    }
   }
 
   bool FileDeserializer::HasData() {


### PR DESCRIPTION
When opening an empty file the FileReader will hang while trying to read the
first event. Steps to reproduce:

```
touch empty.raw
./TestReader.exe empty.raw
```

This patch adds additional checks when opening a file and will throw an
exception if an empty file is detected.
