### PR TITLE
Add BORE event syncing

### DIFF
--- a/main/include/eudaq/Exception.hh
+++ b/main/include/eudaq/Exception.hh
@@ -79,6 +79,7 @@ namespace eudaq {
   EUDAQ_EXCEPTION(FileReadException);
   EUDAQ_EXCEPTION(FileWriteException);
   EUDAQ_EXCEPTION(FileFormatException);
+  EUDAQ_EXCEPTION(SyncException);
   EUDAQ_EXCEPTION(CommunicationException);
   EUDAQ_EXCEPTIONX(BusError, CommunicationException);
 

--- a/main/lib/src/FileReader.cc
+++ b/main/lib/src/FileReader.cc
@@ -428,11 +428,11 @@ namespace eudaq {
         // needs to be added to the queue to allow bore alignment
         m_queue = new eventqueue_t(GetDetectorEvent().NumEvents());
         m_queue->push(m_ev.get());
-        // TODO what to do if SyncBore fails?
-        // if it fails ev is undefined and somehere a segfault will popup.
-        // let's hope that's enough 'error-handling'
+        // if we cannot sync the BOREs id doesnt make sense to continue
         eudaq::Event * ev = NULL;
-        SyncBore(*m_queue, m_des, m_ver, ev);
+        if (!SyncBore(*m_queue, m_des, m_ver, ev)) {
+            EUDAQ_THROWX(SyncException, "could not sync BOREs");
+        };
         m_ev = ev;
       }
     }


### PR DESCRIPTION
During recent testbeams with the Aconite telescope we encountered a problem
where the EORE of the NI producer would get stuck in flight and would end up
as the first event of the next run. This in turn confuses the FileReader since
the BORE of the next run will contain subevents with conflicting run numbers.

Examples w/ for this behaviour can be found at http://www.physi.uni-heidelberg.de/~msmk/eudaq/.

This patch adds support for syncing the BORE subevents. When opening a file
the FileReader will drop subevents until every subevent is a BORE. It gives up
after three tries similar to the current syncing code for regular events.
