### PR TITLE
Serializer.hh fixes

### DIFF
--- a/main/include/eudaq/Serializer.hh
+++ b/main/include/eudaq/Serializer.hh
@@ -109,8 +109,8 @@ namespace eudaq {
 
   template <>
     inline void Serializer::write(const Time & t) {
-      write((int)timeval(t).tv_sec);
-      write((int)timeval(t).tv_usec);
+      write((int)t.GetTimeval().tv_sec);
+      write((int)t.GetTimeval().tv_usec);
     }
 
   template <typename T>

--- a/main/include/eudaq/Time.hh
+++ b/main/include/eudaq/Time.hh
@@ -38,6 +38,12 @@ namespace eudaq {
         tv_sec = tv.tv_sec + tv.tv_usec / 1000000;
       }
       double Seconds() const { return tv_sec + tv_usec / 1e6; }
+      timeval GetTimeval() const {
+        timeval tv;
+        tv.tv_sec = tv_sec;
+        tv.tv_usec = tv_usec;
+        return tv;
+      }
       Time & operator += (const timeval & other) {
         tv_usec += other.tv_usec;
         tv_sec += other.tv_sec + tv_usec / 1000000;
@@ -63,10 +69,7 @@ namespace eudaq {
           (tv_sec == other.tv_sec && tv_usec > other.tv_usec);
       }
       operator const timeval () const {
-        timeval tv;
-        tv.tv_sec = tv_sec;
-        tv.tv_usec = tv_usec;
-        return tv;
+	return GetTimeval();
       }
       std::string Formatted(const std::string & format = TIME_DEFAULT_FORMAT) const;
       static Time Current();


### PR DESCRIPTION
Various fixes to the code in `Serializer.hh`:
- make sure that variables of width <=8bit are handled correctly when shifting data in (fixes eudaq/eudaq#12)
- fixes compilation problems on Clang >3.2 (or Apple LLVM 4.2) (fixes eudaq/eudaq#53)
- addresses type-safety in the serializer code (addresses eudaq/eudaq#54)
