### PR TITLE
bug fix: TLUController was crashing when one was using the flag -n which...

### DIFF
--- a/producers/tlu/src/TLUController.cc
+++ b/producers/tlu/src/TLUController.cc
@@ -707,7 +707,14 @@ namespace tlu {
                     " (expecting " + to_string(old_triggernum) + ")");
       }
       for (unsigned i = 0; i < entries; ++i) {
-        m_buffer.push_back(TLUEntry(timestamp_buffer ? timestamp_buffer[i] : NOTIMESTAMP, trig++,trigger_buffer[i]));
+        
+        
+		  m_buffer.push_back(
+			  TLUEntry(
+			  timestamp_buffer ? timestamp_buffer[i] : NOTIMESTAMP,
+			  trig++, 
+			  trigger_buffer ? trigger_buffer[i]:0)
+			  );
       }
     }
     //mSleep(1);


### PR DESCRIPTION
... is suppressing the readout of the timestamps.

The new feature, which gives the possibility to read out the information which PMT has fired, added one more input parameter to the Constructor of TLUEntry.
this parameter was only set if the time stamp where read out otherwise it would stay a nullptr. the bugfix now checks if the trigger information was set or not. if not initializes it with zero
