### PR TITLE
merging MultipleDataCollectors options into v1.4-dev

### DIFF
--- a/STARTRUN
+++ b/STARTRUN
@@ -1,1 +1,1 @@
-etc/scripts/STARTRUN.local
+etc/scripts/STARTRUN

--- a/conf/ExampleConfig.conf
+++ b/conf/ExampleConfig.conf
@@ -5,15 +5,11 @@
 RunSizeLimit = 1000000000
 
 [DataCollector]
-#FilePattern = "../data/run$6R$X"
-FileType = "native2"
 
 [DataCollector.ExampleProducer1]
-#FilePattern = "../data/run$6R$X"
 FileType = "native2"
 
 [DataCollector.ExampleProducer2]
-#FilePattern = "../data/run$6R$X"
 FileType = "native2"
 
 

--- a/conf/ExampleConfig.conf
+++ b/conf/ExampleConfig.conf
@@ -5,7 +5,18 @@
 RunSizeLimit = 1000000000
 
 [DataCollector]
-FilePattern = "../data/run$6R$X"
+#FilePattern = "../data/run$6R$X"
+FileType = "native2"
+
+[DataCollector.ExampleProducer1]
+#FilePattern = "../data/run$6R$X"
+FileType = "native2"
+
+[DataCollector.ExampleProducer2]
+#FilePattern = "../data/run$6R$X"
+FileType = "native2"
+
+
 
 [LogCollector]
 SaveLevel = EXTRA

--- a/etc/scripts/KILLRUN.local
+++ b/etc/scripts/KILLRUN.local
@@ -1,6 +1,6 @@
 #!/bin/bash
 # cleanup of DAQ
-PROCESSES="TestDataCollector.exe TLUProducer.exe miniTLU_Producer.exe TLUControl.exe NiProducer.exe OnlineMon.exe euLog.exe euRun.exe"
+PROCESSES="TestDataCollector.exe TLUProducer.exe miniTLU_Producer.exe TLUControl.exe NiProducer.exe OnlineMon.exe euLog.exe euRun.exe ExampleProducer.exe ExampleTLUProducer.exe"
 for thisprocess in $PROCESSES
 do
     echo "Checking if $thisprocess is running... "

--- a/etc/scripts/STARTRUN
+++ b/etc/scripts/STARTRUN
@@ -35,11 +35,13 @@ fi
 
 cd bin/
 
-../STARTRUN.local
-../STARTRUN.exampleProducer2
-../STARTRUN.ni
-../STARTRUN.tlu
-../STARTRUN.onlinemon
+../etc/scripts/STARTRUN.local
+#../etc/scripts/STARTRUN.DataCollector
+../etc/scripts/STARTRUN.exampleProducer2in1
+../etc/scripts/STARTRUN.exampleTLUProducer
+#../etc/scripts/STARTRUN.ni
+#../etc/scripts/STARTRUN.tlu
+#../etc/scripts/STARTRUN.onlinemon
 
 
 cd ../

--- a/etc/scripts/STARTRUN
+++ b/etc/scripts/STARTRUN
@@ -35,7 +35,7 @@ fi
 
 cd bin/
 
-../etc/scripts/STARTRUN.local
+../etc/scripts/STARTRUN.gui
 #../etc/scripts/STARTRUN.DataCollector
 ../etc/scripts/STARTRUN.exampleProducer2in1
 ../etc/scripts/STARTRUN.exampleTLUProducer

--- a/etc/scripts/STARTRUN.DataCollector
+++ b/etc/scripts/STARTRUN.DataCollector
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+######################################################################
+# DataCollector
+###############
+printf '\033[22;33m\t TestDataCollector \033[0m \n'
+echo xterm -sb -sl 1000 -geom 80x10-480-900 -fn fixed -T "Data Collector" -e ./TestDataCollector.exe  -r tcp://$HOSTIP:$RCPORT   >> start.log
+xterm -sb -sl 1000 -geom 80x10-480-900 -fn fixed -T "Data Collector" -e "./TestDataCollector.exe  -r tcp://$HOSTIP:$RCPORT " &
+sleep 2
+
+

--- a/etc/scripts/STARTRUN.exampleProducer
+++ b/etc/scripts/STARTRUN.exampleProducer
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+
+######################################################################
+# ExampleProducer
+###############
+if [ -f "ExampleProducer.exe" ]
+then
+    printf '\033[22;33m\t  ExampleProducer  \033[0m \n'
+    xterm -sb -sl 1000 -geom 80x10-480-500 -T 'ExampleProducer' -e './ExampleProducer.exe -r tcp://$TLUIP:$RCPORT' &
+    sleep 1
+else
+    printf '\033[22;31m\t  ExampleProducer not found! \033[0m \n'
+    echo 'Configure EUDAQ with the CMake option "-D BUILD_tlu=ON" and re-run "make install" to install.'
+fi
+#####################################################################
+
+
+

--- a/etc/scripts/STARTRUN.exampleProducer2
+++ b/etc/scripts/STARTRUN.exampleProducer2
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+export Producer1="ExampleProducer1"
+export RCPORT1=44441
+
+export Producer2="ExampleProducer2"
+export RCPORT2=44442
+
+
+######################################################################
+# DataCollector
+###############
+printf '\033[22;33m\t TestDataCollector \033[0m \n'
+echo xterm -sb -sl 1000 -geom 80x10-480-900 -fn fixed -T "Data Collector" -e ./TestDataCollector.exe -n $Producer1 -r tcp://$HOSTIP:$RCPORT  -a $RCPORT1 >> start.log
+xterm -sb -sl 1000 -geom 80x10-480-900 -fn fixed -T "Data Collector" -e "./TestDataCollector.exe -n $Producer1 -r tcp://$HOSTIP:$RCPORT -a $RCPORT1 " &
+sleep 2
+
+
+######################################################################
+# DataCollector
+###############
+printf '\033[22;33m\t TestDataCollector \033[0m \n'
+echo xterm -sb -sl 1000 -geom 80x10-480-900 -fn fixed -T "Data Collector" -e ./TestDataCollector.exe -n $Producer2 -r tcp://$HOSTIP:$RCPORT -a $RCPORT2 >> start.log
+xterm -sb -sl 1000 -geom 80x10-480-900 -fn fixed -T "Data Collector" -e "./TestDataCollector.exe -n $Producer2 -r tcp://$HOSTIP:$RCPORT  -a $RCPORT2" &
+sleep 2
+
+######################################################################
+# ExampleProducer
+###############
+if [ -f "ExampleProducer.exe" ]
+then
+    printf '\033[22;33m\t  ExampleProducer  \033[0m \n'
+    xterm -sb -sl 1000 -geom 80x10-480-500 -T 'ExampleProducer' -e './ExampleProducer.exe -n $Producer1 -r tcp://$HOSTIP:$RCPORT' &
+    sleep 1
+else
+    printf '\033[22;31m\t  ExampleProducer not found! \033[0m \n'
+    echo 'Configure EUDAQ with the CMake option "-D BUILD_tlu=ON" and re-run "make install" to install.'
+fi
+#####################################################################
+
+
+
+######################################################################
+# ExampleProducer
+###############
+if [ -f "ExampleProducer.exe" ]
+then
+    printf '\033[22;33m\t  ExampleProducer2  \033[0m \n'
+    xterm -sb -sl 1000 -geom 80x10-480-500 -T 'ExampleProducer2' -e './ExampleProducer.exe -n $Producer2 -r tcp://$HOSTIP:$RCPORT' &
+    sleep 1
+else
+    printf '\033[22;31m\t  ExampleProducer not found! \033[0m \n'
+    echo 'Configure EUDAQ with the CMake option "-D BUILD_tlu=ON" and re-run "make install" to install.'
+fi
+#####################################################################
+
+
+

--- a/etc/scripts/STARTRUN.exampleProducer2in1
+++ b/etc/scripts/STARTRUN.exampleProducer2in1
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+export Producer1="ExampleProducer1"
+export RCPORT1=44441
+
+export Producer2="ExampleProducer2"
+export RCPORT2=44442
+
+
+######################################################################
+# DataCollector
+###############
+printf '\033[22;33m\t TestDataCollector \033[0m \n'
+echo xterm -sb -sl 1000 -geom 80x10-480-900 -fn fixed -T "Data Collector" -e ./TestDataCollector.exe -n $Producer1 -r tcp://$HOSTIP:$RCPORT  -a $RCPORT1 >> start.log
+#xterm -sb -sl 1000 -geom 80x10-480-900 -fn fixed -T "Data Collector" -e "./TestDataCollector.exe -n $Producer1 -r tcp://$HOSTIP:$RCPORT -a $RCPORT1 " &
+sleep 2
+
+######################################################################
+# DataCollector
+###############
+printf '\033[22;33m\t TestDataCollector \033[0m \n'
+echo xterm -sb -sl 1000 -geom 80x10-480-900 -fn fixed -T "Data Collector" -e ./TestDataCollector.exe  -r tcp://$HOSTIP:$RCPORT  -a $RCPORT1 >> start.log
+xterm -sb -sl 1000 -geom 80x10-480-900 -fn fixed -T "Data Collector" -e "./TestDataCollector.exe  -r tcp://$HOSTIP:$RCPORT -a $RCPORT1 " &
+sleep 2
+
+
+
+######################################################################
+# ExampleProducer
+###############
+if [ -f "ExampleProducer.exe" ]
+then
+    printf '\033[22;33m\t  ExampleProducer  \033[0m \n'
+    xterm -sb -sl 1000 -geom 80x10-480-500 -T 'ExampleProducer' -e './ExampleProducer.exe -n $Producer1 -r tcp://$HOSTIP:$RCPORT' &
+    sleep 1
+else
+    printf '\033[22;31m\t  ExampleProducer not found! \033[0m \n'
+    echo 'Configure EUDAQ with the CMake option "-D BUILD_tlu=ON" and re-run "make install" to install.'
+fi
+#####################################################################
+
+
+
+######################################################################
+# ExampleProducer
+###############
+if [ -f "ExampleProducer.exe" ]
+then
+    printf '\033[22;33m\t  ExampleProducer2  \033[0m \n'
+    xterm -sb -sl 1000 -geom 80x10-480-500 -T 'ExampleProducer2' -e './ExampleProducer.exe -n $Producer2 -r tcp://$HOSTIP:$RCPORT' &
+    sleep 1
+else
+    printf '\033[22;31m\t  ExampleProducer not found! \033[0m \n'
+    echo 'Configure EUDAQ with the CMake option "-D BUILD_tlu=ON" and re-run "make install" to install.'
+fi
+#####################################################################
+
+
+

--- a/etc/scripts/STARTRUN.exampleProducer2in1
+++ b/etc/scripts/STARTRUN.exampleProducer2in1
@@ -8,15 +8,7 @@ export RCPORT2=44442
 
 
 ######################################################################
-# DataCollector
-###############
-printf '\033[22;33m\t TestDataCollector \033[0m \n'
-echo xterm -sb -sl 1000 -geom 80x10-480-900 -fn fixed -T "Data Collector" -e ./TestDataCollector.exe -n $Producer1 -r tcp://$HOSTIP:$RCPORT  -a $RCPORT1 >> start.log
-#xterm -sb -sl 1000 -geom 80x10-480-900 -fn fixed -T "Data Collector" -e "./TestDataCollector.exe -n $Producer1 -r tcp://$HOSTIP:$RCPORT -a $RCPORT1 " &
-sleep 2
-
-######################################################################
-# DataCollector
+# Default Data Collector
 ###############
 printf '\033[22;33m\t TestDataCollector \033[0m \n'
 echo xterm -sb -sl 1000 -geom 80x10-480-900 -fn fixed -T "Data Collector" -e ./TestDataCollector.exe  -r tcp://$HOSTIP:$RCPORT  -a $RCPORT1 >> start.log
@@ -26,12 +18,12 @@ sleep 2
 
 
 ######################################################################
-# ExampleProducer
+# ExampleProducer 1
 ###############
 if [ -f "ExampleProducer.exe" ]
 then
     printf '\033[22;33m\t  ExampleProducer  \033[0m \n'
-    xterm -sb -sl 1000 -geom 80x10-480-500 -T 'ExampleProducer' -e './ExampleProducer.exe -n $Producer1 -r tcp://$HOSTIP:$RCPORT' &
+    xterm -sb -sl 1000 -geom 80x10-480-500 -T 'ExampleProducer1' -e './ExampleProducer.exe -n $Producer1 -r tcp://$HOSTIP:$RCPORT' &
     sleep 1
 else
     printf '\033[22;31m\t  ExampleProducer not found! \033[0m \n'
@@ -42,7 +34,7 @@ fi
 
 
 ######################################################################
-# ExampleProducer
+# ExampleProducer 2
 ###############
 if [ -f "ExampleProducer.exe" ]
 then

--- a/etc/scripts/STARTRUN.exampleTLUProducer
+++ b/etc/scripts/STARTRUN.exampleTLUProducer
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+
+######################################################################
+# ExampleTLUProducer
+###############
+if [ -f "ExampleTLUProducer.exe" ]
+then
+    printf '\033[22;33m\t  ExampleTLUProducer  \033[0m \n'
+    xterm -sb -sl 1000 -geom 80x10-480-500 -T 'ExampleTLUProducer' -e './ExampleTLUProducer.exe -n TLU -r tcp://$TLUIP:$RCPORT' &
+    sleep 1
+else
+    printf '\033[22;31m\t  ExampleTLUProducer not found! \033[0m \n'
+    echo 'Configure EUDAQ with the CMake option "-D BUILD_tlu=ON" and re-run "make install" to install.'
+fi
+#####################################################################
+
+
+

--- a/etc/scripts/STARTRUN.gui
+++ b/etc/scripts/STARTRUN.gui
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+#=====================================================================
+printf '\033[22;33m\t Starting Subprocesses \033[0m \n'
+#=====================================================================
+######################################################################
+# euRun
+###############
+printf '\033[22;33m\t RunControl \033[0m \n'
+echo ./euRun.exe -x 0 -y 0 -w 650 -g 550 -a tcp://$RCPORT > start.log
+./euRun.exe -x 0 -y 0 -w 650 -g 550 -a tcp://$RCPORT &
+sleep 1
+######################################################################
+# euLog
+###############
+printf '\033[22;33m\t Logger  \033[0m \n'
+echo ./euLog.exe -x 0 -y 550 -w 1500 -g 450 -r tcp://$HOSTIP:$RCPORT >> start.log
+./euLog.exe -x 0 -y 550 -w 1500 -g 450 -r tcp://$HOSTIP:$RCPORT &
+sleep 2
+
+
+
+
+printf ' \n'
+printf ' \n'
+printf ' \n'
+printf '\033[1;32;48m\t ...Done!\033[0m \n'
+printf '\033[1;32;48mSTART OF DAQ COMPLETE\033[0m \n'

--- a/etc/scripts/STARTRUN.local
+++ b/etc/scripts/STARTRUN.local
@@ -20,6 +20,30 @@ sleep 2
 
 
 ######################################################################
+# DataCollector
+###############
+printf '\033[22;33m\t TestDataCollector \033[0m \n'
+echo xterm -sb -sl 1000 -geom 80x10-480-900 -fn fixed -T "Data Collector" -e ./TestDataCollector.exe  -r tcp://$HOSTIP:$RCPORT   >> start.log
+xterm -sb -sl 1000 -geom 80x10-480-900 -fn fixed -T "Data Collector" -e "./TestDataCollector.exe  -r tcp://$HOSTIP:$RCPORT " &
+sleep 2
+
+######################################################################
+# TLU producer
+###############
+if [ -f "TLUProducer.exe" ]
+then
+    export NAME="TLU"
+    printf '\033[22;33m\t  TLUProducer  \033[0m \n'
+    echo xterm -sb -sl 1000 -geom 80x10-480-500 -T 'TLU Producer' -e ./TLUProducer.exe -n $NAME -r tcp://$TLUIP:$RCPORT >> start.log
+    xterm -sb -sl 1000 -geom 80x10-480-500 -T 'TLU Producer' -e ./TLUProducer.exe -n $NAME -r tcp://$TLUIP:$RCPORT &
+    sleep 1
+else
+    printf '\033[22;31m\t  TLUProducer not found! \033[0m \n'
+    echo 'Configure EUDAQ with the CMake option "-D BUILD_tlu=ON" and re-run "make install" to install.'
+fi
+#####################################################################
+
+######################################################################
 # NI Producer
 ###############
 if [ -f "NiProducer.exe" ]
@@ -32,19 +56,7 @@ else
     printf '\033[22;31m\t  NiProducer for linux not found!  \033[0m \n'
     echo 'Configure EUDAQ with the CMake option "-D BUILD_ni=ON" and re-run "make install" to install.'
 fi
-######################################################################
-# TLU producer
-###############
-if [ -f "TLUProducer.exe" ]
-then
-    printf '\033[22;33m\t  TLUProducer  \033[0m \n'
-    echo xterm -sb -sl 1000 -geom 80x10-480-500 -T 'TLU Producer' -e ./TLUProducer.exe -r tcp://$TLUIP:$RCPORT >> start.log
-    xterm -sb -sl 1000 -geom 80x10-480-500 -T 'TLU Producer' -e ./TLUProducer.exe -r tcp://$TLUIP:$RCPORT &
-    sleep 1
-else
-    printf '\033[22;31m\t  TLUProducer not found! \033[0m \n'
-    echo 'Configure EUDAQ with the CMake option "-D BUILD_tlu=ON" and re-run "make install" to install.'
-fi
+
 #####################################################################
 ######################################################################
 # Online Monitor

--- a/etc/scripts/STARTRUN.local
+++ b/etc/scripts/STARTRUN.local
@@ -1,39 +1,5 @@
 #!/bin/bash
 
-export RCPORT=44000
-[ "$1" != "" ] && RCPORT=$1
-
-export HOSTIP=127.0.0.1
-export TLUIP=127.0.0.1
-export HOSTNAME=127.0.0.1
-
-cd `dirname $0`
-export LD_LIBRARY_PATH="`pwd`/bin:$LD_LIBRARY_PATH"
-
-printf '\033[1;32;48m \t STARTING DAQ LOCALLY\033[0m \n'
-echo $(date)
-printf '\033[22;33m\t Cleaning up first...  \033[0m \n'
-
-if [ -f KILLRUN.local ]
-then
-    sh KILLRUN.local
-else
-    sh KILLRUN
-fi
-
-printf '\033[22;31m\t End of killall \033[0m \n'
-
-sleep 1
-
-######################################################################
-if [ -n "`ls data/run*.raw`" ]
-then
-    printf '\033[22;33m\t Making sure all data files are properly writeprotected \033[0m \n'
-    chmod a=rw data/run*.raw
-    printf '\033[22;32m\t ...Done!\033[0m \n'
-fi
-
-cd bin
 #=====================================================================
 printf '\033[22;33m\t Starting Subprocesses \033[0m \n'
 #=====================================================================
@@ -41,27 +7,26 @@ printf '\033[22;33m\t Starting Subprocesses \033[0m \n'
 # euRun
 ###############
 printf '\033[22;33m\t RunControl \033[0m \n'
+echo ./euRun.exe -x 0 -y 0 -w 650 -g 550 -a tcp://$RCPORT > start.log
 ./euRun.exe -x 0 -y 0 -w 650 -g 550 -a tcp://$RCPORT &
 sleep 1
 ######################################################################
 # euLog
 ###############
 printf '\033[22;33m\t Logger  \033[0m \n'
-./euLog.exe -x 0 -y 550 -w 1500 -g 450 -r tcp://$HOSTIP:44000 &
-sleep 1
-######################################################################
-# DataCollector
-###############
-printf '\033[22;33m\t TestDataCollector \033[0m \n'
-xterm -sb -sl 1000 -geom 80x10-480-900 -fn fixed -T "Data Collector" -e './TestDataCollector.exe -r tcp://$HOSTIP:$RCPORT' &
-sleep 1
+echo ./euLog.exe -x 0 -y 550 -w 1500 -g 450 -r tcp://$HOSTIP:$RCPORT >> start.log
+./euLog.exe -x 0 -y 550 -w 1500 -g 450 -r tcp://$HOSTIP:$RCPORT &
+sleep 2
+
+
 ######################################################################
 # NI Producer
 ###############
 if [ -f "NiProducer.exe" ]
 then
     printf '\033[22;33m\t  NiProducer for linux  \033[0m \n'
-    xterm -sb -sl 1000 -geom 80x10-480-700 -T 'Ni Producer for Linux' -e './NiProducer.exe -r tcp://$HOSTIP:$RCPORT' &
+    echo xterm -sb -sl 1000 -geom 80x10-480-700 -T 'Ni Producer for Linux' -e ./NiProducer.exe -r tcp://$HOSTIP:$RCPORT >> start.log
+    xterm -sb -sl 1000 -geom 80x10-480-700 -T 'Ni Producer for Linux' -e ./NiProducer.exe -r tcp://$HOSTIP:$RCPORT &
     sleep 1
 else
     printf '\033[22;31m\t  NiProducer for linux not found!  \033[0m \n'
@@ -73,7 +38,8 @@ fi
 if [ -f "TLUProducer.exe" ]
 then
     printf '\033[22;33m\t  TLUProducer  \033[0m \n'
-    xterm -sb -sl 1000 -geom 80x10-480-500 -T 'TLU Producer' -e './TLUProducer.exe -r tcp://$TLUIP:$RCPORT' &
+    echo xterm -sb -sl 1000 -geom 80x10-480-500 -T 'TLU Producer' -e ./TLUProducer.exe -r tcp://$TLUIP:$RCPORT >> start.log
+    xterm -sb -sl 1000 -geom 80x10-480-500 -T 'TLU Producer' -e ./TLUProducer.exe -r tcp://$TLUIP:$RCPORT &
     sleep 1
 else
     printf '\033[22;31m\t  TLUProducer not found! \033[0m \n'
@@ -86,6 +52,7 @@ fi
 if [ -f "OnlineMon.exe" ]
 then
     printf '\033[22;33m\t  Online Monitor  \033[0m \n'
+    echo ./OnlineMon.exe  -sc 10 -s 0 -tc 0 -r tcp://$HOSTIP:$RCPORT >> start.log
     ./OnlineMon.exe  -sc 10 -s 0 -tc 0 -r tcp://$HOSTIP:$RCPORT &
 else
     printf '\033[22;31m\t  Online monitor not found! \033[0m \n'

--- a/etc/scripts/STARTRUN.ni
+++ b/etc/scripts/STARTRUN.ni
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+
+######################################################################
+# NI Producer
+###############
+if [ -f "NiProducer.exe" ]
+then
+    printf '\033[22;33m\t  NiProducer for linux  \033[0m \n'
+    echo xterm -sb -sl 1000 -geom 80x10-480-700 -T 'Ni Producer for Linux' -e ./NiProducer.exe -r tcp://$HOSTIP:$RCPORT >> start.log
+    xterm -sb -sl 1000 -geom 80x10-480-700 -T 'Ni Producer for Linux' -e ./NiProducer.exe -r tcp://$HOSTIP:$RCPORT &
+    sleep 1
+else
+    printf '\033[22;31m\t  NiProducer for linux not found!  \033[0m \n'
+    echo 'Configure EUDAQ with the CMake option "-D BUILD_ni=ON" and re-run "make install" to install.'
+fi
+

--- a/etc/scripts/STARTRUN.onlinemon
+++ b/etc/scripts/STARTRUN.onlinemon
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+######################################################################
+# Online Monitor
+###############
+if [ -f "OnlineMon.exe" ]
+then
+    printf '\033[22;33m\t  Online Monitor  \033[0m \n'
+    echo ./OnlineMon.exe  -sc 10 -s 0 -tc 0 -r tcp://$HOSTIP:$RCPORT >> start.log
+    ./OnlineMon.exe  -sc 10 -s 0 -tc 0 -r tcp://$HOSTIP:$RCPORT &
+else
+    printf '\033[22;31m\t  Online monitor not found! \033[0m \n'
+    echo 'Configure EUDAQ with the CMake option "-D BUILD_onlinemon=ON" and re-run "make install" to install.'
+fi
+#####################################################################
+
+
+

--- a/etc/scripts/STARTRUN.tlu
+++ b/etc/scripts/STARTRUN.tlu
@@ -4,9 +4,10 @@
 ###############
 if [ -f "TLUProducer.exe" ]
 then
+    export NAME="TLU"
     printf '\033[22;33m\t  TLUProducer  \033[0m \n'
-    echo xterm -sb -sl 1000 -geom 80x10-480-500 -T 'TLU Producer' -e ./TLUProducer.exe -r tcp://$TLUIP:$RCPORT >> start.log
-    xterm -sb -sl 1000 -geom 80x10-480-500 -T 'TLU Producer' -e ./TLUProducer.exe -r tcp://$TLUIP:$RCPORT &
+    echo xterm -sb -sl 1000 -geom 80x10-480-500 -T 'TLU Producer' -e ./TLUProducer.exe -n $NAME -r tcp://$TLUIP:$RCPORT >> start.log
+    xterm -sb -sl 1000 -geom 80x10-480-500 -T 'TLU Producer' -e ./TLUProducer.exe -n $NAME -r tcp://$TLUIP:$RCPORT &
     sleep 1
 else
     printf '\033[22;31m\t  TLUProducer not found! \033[0m \n'

--- a/etc/scripts/STARTRUN.tlu
+++ b/etc/scripts/STARTRUN.tlu
@@ -1,0 +1,16 @@
+#!/bin/bash
+######################################################################
+# TLU producer
+###############
+if [ -f "TLUProducer.exe" ]
+then
+    printf '\033[22;33m\t  TLUProducer  \033[0m \n'
+    echo xterm -sb -sl 1000 -geom 80x10-480-500 -T 'TLU Producer' -e ./TLUProducer.exe -r tcp://$TLUIP:$RCPORT >> start.log
+    xterm -sb -sl 1000 -geom 80x10-480-500 -T 'TLU Producer' -e ./TLUProducer.exe -r tcp://$TLUIP:$RCPORT &
+    sleep 1
+else
+    printf '\033[22;31m\t  TLUProducer not found! \033[0m \n'
+    echo 'Configure EUDAQ with the CMake option "-D BUILD_tlu=ON" and re-run "make install" to install.'
+fi
+#####################################################################
+

--- a/etc/scripts/start.sh
+++ b/etc/scripts/start.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+export RCPORT=44000
+[ "$1" != "" ] && RCPORT=$1
+
+export HOSTIP=127.0.0.1
+export TLUIP=127.0.0.1
+export HOSTNAME=127.0.0.1
+
+cd `dirname $0`
+export LD_LIBRARY_PATH="`pwd`/lib:$LD_LIBRARY_PATH"
+
+printf '\033[1;32;48m \t STARTING DAQ LOCALLY\033[0m \n'
+echo $(date)
+printf '\033[22;33m\t Cleaning up first...  \033[0m \n'
+
+if [ -f KILLRUN.local ]
+then
+    sh KILLRUN.local
+else
+    sh KILLRUN
+fi
+
+printf '\033[22;31m\t End of killall \033[0m \n'
+
+sleep 1
+
+######################################################################
+if [ -n "`ls data/run*.raw`" ]
+then
+    printf '\033[22;33m\t Making sure all data files are properly writeprotected \033[0m \n'
+    chmod a=rw data/run*.raw
+    printf '\033[22;32m\t ...Done!\033[0m \n'
+fi
+
+cd bin/
+
+../STARTRUN.local
+../STARTRUN.exampleProducer2
+../STARTRUN.ni
+../STARTRUN.tlu
+../STARTRUN.onlinemon
+
+
+cd ../
+
+
+printf ' \n'
+printf ' \n'
+printf ' \n'
+printf '\033[1;32;48m\t ...Done!\033[0m \n'
+printf '\033[1;32;48mSTART OF DAQ COMPLETE\033[0m \n'

--- a/gui/include/euLog.hh
+++ b/gui/include/euLog.hh
@@ -105,7 +105,17 @@ class LogCollectorGUI : public QMainWindow,
         CheckRegistered();
         emit RecMessage(msg);
       }
+ 
+      virtual void OnTerminate() {
+        SetStatus(eudaq::Status::LVL_OK,"LC Terminating");
+        std::cout << "terminating!" << std::endl;
+        QApplication::quit();
+        exit(0);
+      }
+
+
       void AddSender(const std::string & type, const std::string & name = "");
+
       void closeEvent(QCloseEvent *) {
         std::cout << "Closing!" << std::endl;
         QApplication::quit();

--- a/gui/include/euRun.hh
+++ b/gui/include/euRun.hh
@@ -64,7 +64,7 @@ class RunControlGUI : public QMainWindow, public Ui::wndRun, public eudaq::RunCo
         event->ignore();
       } else {
         Terminate();
-	eudaq::mSleep(1000);
+	eudaq::mSleep(500);
         event->accept();
       }
     }

--- a/gui/include/euRun.hh
+++ b/gui/include/euRun.hh
@@ -64,7 +64,7 @@ class RunControlGUI : public QMainWindow, public Ui::wndRun, public eudaq::RunCo
         event->ignore();
       } else {
         Terminate();
-	eudaq::mSleep(1);
+	eudaq::mSleep(1000);
         event->accept();
       }
     }
@@ -79,7 +79,7 @@ class RunControlGUI : public QMainWindow, public Ui::wndRun, public eudaq::RunCo
 			btnStop->setEnabled(state == ST_RUNNING);
 		}
 
-  void on_btnTerminate_clicked() { close(); }
+    void on_btnTerminate_clicked() { close(); }
 
     void on_btnConfig_clicked() {
         std::string settings = cmbConfig->currentText().toStdString();

--- a/gui/include/euRun.hh
+++ b/gui/include/euRun.hh
@@ -116,7 +116,7 @@ class RunControlGUI : public QMainWindow, public Ui::wndRun, public eudaq::RunCo
       if (!m_stopping) {
         if (m_runsizelimit >= 1024 && m_filebytes >= m_runsizelimit) {
           EUDAQ_INFO("File limit reached: " + to_string(m_filebytes) + " > " + to_string(m_runsizelimit));
-          eudaq::mSleep(1);
+          eudaq::mSleep(1000);
           StopRun(false);
           eudaq::mSleep(8000);
           while (m_producerbusy) {

--- a/gui/include/euRun.hh
+++ b/gui/include/euRun.hh
@@ -64,7 +64,7 @@ class RunControlGUI : public QMainWindow, public Ui::wndRun, public eudaq::RunCo
         event->ignore();
       } else {
         Terminate();
-	eudaq::mSleep(500);
+	eudaq::mSleep(1);
         event->accept();
       }
     }
@@ -116,7 +116,7 @@ class RunControlGUI : public QMainWindow, public Ui::wndRun, public eudaq::RunCo
       if (!m_stopping) {
         if (m_runsizelimit >= 1024 && m_filebytes >= m_runsizelimit) {
           EUDAQ_INFO("File limit reached: " + to_string(m_filebytes) + " > " + to_string(m_runsizelimit));
-          eudaq::mSleep(1000);
+          eudaq::mSleep(1);
           StopRun(false);
           eudaq::mSleep(8000);
           while (m_producerbusy) {

--- a/main/exe/src/ExampleProducer.cxx
+++ b/main/exe/src/ExampleProducer.cxx
@@ -73,12 +73,16 @@ class ExampleProducer : public eudaq::Producer {
 
       // Send an EORE after all the real events have been sent
       // You can also set tags on it (as with the BORE) if necessary
-      SendEvent(eudaq::RawDataEvent::EORE("Test", m_run, ++m_ev));
-    }
+      SendEvent(eudaq::RawDataEvent::EORE(EVENT_TYPE, m_run, ++m_ev));
+ 
+      // At the end, set the status that will be displayed in the Run Control.
+      SetStatus(eudaq::Status::LVL_OK, "Stopped");
+   }
 
     // This gets called when the Run Control is terminating,
     // we should also exit.
     virtual void OnTerminate() {
+      SetStatus(eudaq::Status::LVL_OK, "Terminating");
       std::cout << "Terminating..." << std::endl;
       done = true;
     }

--- a/main/exe/src/ExampleProducer.cxx
+++ b/main/exe/src/ExampleProducer.cxx
@@ -9,6 +9,7 @@
 #include <iostream>
 #include <ostream>
 #include <vector>
+#include <ctime>
 
 // A name to identify the raw data format of the events generated
 // Modify this to something appropriate for your producer.
@@ -112,7 +113,7 @@ class ExampleProducer : public eudaq::Producer {
         // If we get here, there must be data to read out
         // Create a RawDataEvent to contain the event data to be sent
         eudaq::RawDataEvent ev(EVENT_TYPE, m_run, m_ev);
-
+        ev.setTimeStamp( clock() ); 
         for (unsigned plane = 0; plane < hardware.NumSensors(); ++plane) {
           // Read out a block of raw data from the hardware
           std::vector<unsigned char> buffer = hardware.ReadSensor(plane);

--- a/main/include/eudaq/DataCollector.hh
+++ b/main/include/eudaq/DataCollector.hh
@@ -45,6 +45,7 @@ namespace eudaq {
         std::list<std::shared_ptr<Event> > events;
       };
 
+      const std::string m_name; // name of the Data Collector
       const std::string m_runnumberfile; // path to the file containing the run number
       void DataHandler(TransportEvent & ev);
       size_t GetInfo(const ConnectionInfo & id);

--- a/main/include/eudaq/FileWriter.hh
+++ b/main/include/eudaq/FileWriter.hh
@@ -11,12 +11,16 @@ namespace eudaq {
     public:
       FileWriter();
       virtual void StartRun(unsigned runnumber) = 0;
+      virtual void StartRun( const std::string & name, unsigned int runnumber) {};
       virtual void WriteEvent(const DetectorEvent &) = 0;
       virtual uint64_t FileBytes() const = 0;
       void SetFilePattern(const std::string & p) { m_filepattern = p; }
       virtual ~FileWriter() {}
     protected:
       std::string m_filepattern;
+      std::string m_name;
+      unsigned int m_runNumber;
+      unsigned int m_fileNumber;
   };
 
 

--- a/main/lib/src/DataCollector.cc
+++ b/main/lib/src/DataCollector.cc
@@ -20,7 +20,7 @@ namespace eudaq {
   } // anonymous namespace
 
   DataCollector::DataCollector(const std::string & name, const std::string & runcontrol, const std::string & listenaddress, const std::string & runnumberfile) :
-    CommandReceiver("DataCollector", name, runcontrol, false), m_runnumberfile(runnumberfile), m_done(false), m_listening(true), m_dataserver(TransportFactory::CreateServer(listenaddress)), m_thread(), m_numwaiting(0), m_itlu((size_t) -1), m_runnumber(
+    CommandReceiver("DataCollector", name, runcontrol, false), m_name(name), m_runnumberfile(runnumberfile), m_done(false), m_listening(true), m_dataserver(TransportFactory::CreateServer(listenaddress)), m_thread(), m_numwaiting(0), m_itlu((size_t) -1), m_runnumber(
      ReadFromFile(runnumberfile, 0U)), m_eventnumber(0), m_runstart(0) {
       m_dataserver->SetCallback(TransportCallback(this, &DataCollector::DataHandler));
       EUDAQ_DEBUG("Instantiated datacollector with name: " + name);
@@ -80,7 +80,8 @@ namespace eudaq {
       if (!m_writer) {
         EUDAQ_THROW("You must configure before starting a run");
       }
-      m_writer->StartRun(runnumber);
+//      m_writer->StartRun(runnumber);
+      m_writer->StartRun(m_name, runnumber);
       WriteToFile(m_runnumberfile, runnumber);
       m_runnumber = runnumber;
       m_eventnumber = 0;

--- a/main/lib/src/ExampleHardware.cc
+++ b/main/lib/src/ExampleHardware.cc
@@ -70,7 +70,7 @@ namespace eudaq {
     setlittleendian<unsigned short>(&result[0], m_width);
     setlittleendian<unsigned short>(&result[2], m_height);
     setlittleendian<unsigned short>(&result[4], m_triggerid);
-    if (sensorid % 2 == 0) {
+    if ( false ) {
       // Raw Data
       setlittleendian(&result[6], static_cast<unsigned short>(0));
       std::vector<unsigned char> data = MakeRawEvent(m_width, m_height);

--- a/main/lib/src/FileNamer.cc
+++ b/main/lib/src/FileNamer.cc
@@ -5,7 +5,8 @@
 
 namespace eudaq {
 
-  const std::string FileNamer::default_pattern = "../data/run$6R$S$3N$X";
+//  const std::string FileNamer::default_pattern = "../data/run$6R$S$3N$X";
+  const std::string FileNamer::default_pattern = "../data/run$6R$s$3i_$N$X";
 
   FileNamer::FileNamer(const std::string & p) {
     std::string pattern(p == "" ? default_pattern : p);

--- a/producers/tlu/CMakeLists.txt
+++ b/producers/tlu/CMakeLists.txt
@@ -10,11 +10,14 @@ add_executable(TLUControl.exe src/TLUControl.cxx src/TLUController.cc src/TLU_US
 add_executable(TLUProducer.exe src/TLUProducer.cxx src/TLUController.cc src/TLU_USB.cc src/USBTracer.cc src/TLUAddresses1.cc src/TLUAddresses2.cc src/win_uSleep.cc)
 add_executable(TLUReset.exe src/TLUReset.cxx src/TLUController.cc src/TLU_USB.cc src/USBTracer.cc src/TLUAddresses1.cc src/TLUAddresses2.cc src/win_uSleep.cc)
 
+add_executable(ExampleTLUProducer.exe src/ExampleTLUProducer.cxx src/TLU_USB.cc src/USBTracer.cc src/TLUAddresses1.cc src/TLUAddresses2.cc src/win_uSleep.cc)
+
 target_link_libraries(TLUControl.exe   EUDAQ ${EUDAQ_THREADS_LIB} ${LIBUSB_LIBRARIES} ${ZESTSC1_LIBRARIES})
 target_link_libraries(TLUProducer.exe   EUDAQ ${EUDAQ_THREADS_LIB} ${LIBUSB_LIBRARIES} ${ZESTSC1_LIBRARIES})
 target_link_libraries(TLUReset.exe   EUDAQ ${EUDAQ_THREADS_LIB} ${LIBUSB_LIBRARIES} ${ZESTSC1_LIBRARIES})
+target_link_libraries(ExampleTLUProducer.exe   EUDAQ ${EUDAQ_THREADS_LIB} ${LIBUSB_LIBRARIES} ${ZESTSC1_LIBRARIES})
 
-INSTALL(TARGETS TLUControl.exe TLUProducer.exe TLUReset.exe
+INSTALL(TARGETS TLUControl.exe TLUProducer.exe TLUReset.exe ExampleTLUProducer.exe
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib)

--- a/producers/tlu/src/ExampleTLUProducer.cxx
+++ b/producers/tlu/src/ExampleTLUProducer.cxx
@@ -1,0 +1,175 @@
+#include "eudaq/Configuration.hh"
+#include "eudaq/Producer.hh"
+#include "eudaq/TLUEvent.hh" // for the TLU event
+#include "eudaq/Utils.hh"
+#include "eudaq/Logger.hh"
+#include "eudaq/OptionParser.hh"
+
+#include "tlu/USBTracer.hh"
+#include <iostream>
+#include <ostream>
+#include <cctype>
+#include <memory>
+#include <ctime>
+
+typedef eudaq::TLUEvent TLUEvent;
+using eudaq::to_string;
+using eudaq::to_hex;
+using namespace tlu;
+#ifdef WIN32
+ZESTSC1_ERROR_FUNC ZestSC1_ErrorHandler=NULL;  // Windows needs some parameters for this. i dont know where it will be called so we need to check it in future
+char *ZestSC1_ErrorStrings[]={"bla bla","blub"};
+#endif
+
+class ExampleTLUProducer: public eudaq::Producer {
+public:
+	ExampleTLUProducer(const std::string & name, const std::string & runcontrol) :
+	  eudaq::Producer(name, runcontrol), m_run(0), m_ev(0), trigger_interval(0), 
+	  timestamps(true), done(false), timestamp_per_run(false), TLUStarted(false), TLUJustStopped(false), lasttime(0) {
+	}
+	void MainLoop() {
+		do {
+			bool JustStopped = TLUJustStopped;
+			if (JustStopped) {
+				eudaq::mSleep(100);
+			}
+
+			if( TLUStarted ) {
+                        	m_ev++;
+	                        uint64_t t = clock(); 
+				TLUEvent ev(m_run, m_ev, t);
+				SendEvent(ev);
+                        }
+
+			if (JustStopped) {
+				SendEvent(TLUEvent::EORE(m_run, ++m_ev));
+				TLUJustStopped = false;
+			}
+
+		} while (!done);
+	}
+	virtual void OnConfigure(const eudaq::Configuration & param) {
+		SetStatus(eudaq::Status::LVL_OK, "Wait");
+		try {
+			std::cout << "Configuring (" << param.Name() << ")..." << std::endl;
+
+			trigger_interval = param.Get("TriggerInterval", 0);
+			timestamps = param.Get("Timestamps", 1);
+			timestamp_per_run = param.Get("TimestampPerRun", false);
+			// ***
+			eudaq::mSleep(1000);
+
+			std::cout << "...Configured (" << param.Name() << ")" << std::endl;
+			EUDAQ_INFO("Configured (" + param.Name() + ")");
+			SetStatus(eudaq::Status::LVL_OK, "Configured (" + param.Name() + ")");
+		} catch (const std::exception & e) {
+			printf("Caught exception: %s\n", e.what());
+			SetStatus(eudaq::Status::LVL_ERROR, "Configuration Error");
+		} catch (...) {
+			printf("Unknown exception\n");
+			SetStatus(eudaq::Status::LVL_ERROR, "Configuration Error");
+		}
+	}
+
+	virtual void OnStartRun(unsigned param) {
+		SetStatus(eudaq::Status::LVL_OK, "Wait");
+		try {
+			m_run = param;
+			m_ev = 0;
+			std::cout << "Start Run: " << param << std::endl;
+			TLUEvent ev(TLUEvent::BORE(m_run));
+			ev.SetTag("TimestampZero", to_string( clock() ) );
+			eudaq::mSleep(5000); // temporarily, to fix startup with EUDRB
+			SendEvent(ev);
+			eudaq::mSleep(5000);
+			TLUStarted = true;
+			SetStatus(eudaq::Status::LVL_OK, "Started");
+		} catch (const std::exception & e) {
+			printf("Caught exception: %s\n", e.what());
+			SetStatus(eudaq::Status::LVL_ERROR, "Start Error");
+		} catch (...) {
+			printf("Unknown exception\n");
+			SetStatus(eudaq::Status::LVL_ERROR, "Start Error");
+		}
+
+   	        // At the end, set the status that will be displayed in the Run Control.
+		SetStatus(eudaq::Status::LVL_OK, "Running");
+	}
+
+	virtual void OnStopRun() {
+		try {
+			std::cout << "Stop Run" << std::endl;
+			TLUStarted = false;
+			TLUJustStopped = true;
+			while (TLUJustStopped) {
+				eudaq::mSleep(100);
+			}
+			SetStatus(eudaq::Status::LVL_OK, "Stopped");
+		} catch (const std::exception & e) {
+			printf("Caught exception: %s\n", e.what());
+			SetStatus(eudaq::Status::LVL_ERROR, "Stop Error");
+		} catch (...) {
+			printf("Unknown exception\n");
+			SetStatus(eudaq::Status::LVL_ERROR, "Stop Error");
+		}
+	}
+
+	virtual void OnTerminate() {
+		SetStatus(eudaq::Status::LVL_OK, "Terminating");
+		std::cout << "Terminate (press enter)" << std::endl;
+		done = true;
+	}
+
+	virtual void OnReset() {
+		try {
+			std::cout << "Reset" << std::endl;
+			SetStatus(eudaq::Status::LVL_OK);
+			SetStatus(eudaq::Status::LVL_OK, "Reset");
+		} catch (const std::exception & e) {
+			printf("Caught exception: %s\n", e.what());
+			SetStatus(eudaq::Status::LVL_ERROR, "Reset Error");
+		} catch (...) {
+			printf("Unknown exception\n");
+			SetStatus(eudaq::Status::LVL_ERROR, "Reset Error");
+		}
+	}
+	virtual void OnStatus() {
+		m_status.SetTag("TRIG", to_string(m_ev));
+	}
+	virtual void OnUnrecognised(const std::string & cmd, const std::string & param) {
+		std::cout << "Unrecognised: (" << cmd.length() << ") " << cmd;
+		if (param.length() > 0)
+			std::cout << " (" << param << ")";
+		std::cout << std::endl;
+		SetStatus(eudaq::Status::LVL_WARN, "Unrecognised command");
+	}
+private:
+	unsigned m_run, m_ev;
+        unsigned trigger_interval;
+	bool timestamps, done, timestamp_per_run;
+	bool TLUStarted;
+	bool TLUJustStopped;
+	uint64_t lasttime;
+};
+
+int main(int /*argc*/, const char ** argv) {
+	eudaq::OptionParser op("EUDAQ TLU Producer", "1.0", "The Producer task for the Trigger Logic Unit");
+	eudaq::Option<std::string> rctrl(op, "r", "runcontrol", "tcp://localhost:44000", "address", "The address of the RunControl application");
+	eudaq::Option<std::string> level(op, "l", "log-level", "NONE", "level", "The minimum level for displaying log messages locally");
+	eudaq::Option<std::string> op_trace(op, "t", "tracefile", "", "filename", "Log file for tracing USB access");
+        eudaq::Option<std::string> name (op, "n", "name", "Example", "string", "The name of this Producer");
+	try {
+		op.Parse(argv);
+		EUDAQ_LOG_LEVEL(level.Value());
+		if (op_trace.Value() != "") {
+			setusbtracefile(op_trace.Value());
+		}
+		ExampleTLUProducer producer(name.Value(), rctrl.Value());
+		producer.MainLoop();
+		std::cout << "Quitting" << std::endl;
+	} catch (...) {
+		return op.HandleMainException();
+	}
+	return 0;
+}
+

--- a/producers/tlu/src/TLUProducer.cxx
+++ b/producers/tlu/src/TLUProducer.cxx
@@ -23,8 +23,8 @@ char *ZestSC1_ErrorStrings[]={"bla bla","blub"};
 
 class TLUProducer: public eudaq::Producer {
 public:
-	TLUProducer(const std::string & runcontrol) :
-	  eudaq::Producer("TLU", runcontrol), m_run(0), m_ev(0), trigger_interval(0), dut_mask(0), veto_mask(0), and_mask(255),
+	TLUProducer(const std::string & name, const std::string & runcontrol) :
+	  eudaq::Producer(name, runcontrol), m_run(0), m_ev(0), trigger_interval(0), dut_mask(0), veto_mask(0), and_mask(255),
 	  or_mask(0), pmtvcntlmod(0), strobe_period(0), strobe_width(0), enable_dut_veto(0), trig_rollover(0), readout_delay(100),
 	  timestamps(true), done(false), timestamp_per_run(false), TLUStarted(false), TLUJustStopped(false), lasttime(0), m_tlu(0) {
 	  for(int i = 0; i < TLU_PMTS; i++)
@@ -285,13 +285,15 @@ int main(int /*argc*/, const char ** argv) {
 	eudaq::Option<std::string> rctrl(op, "r", "runcontrol", "tcp://localhost:44000", "address", "The address of the RunControl application");
 	eudaq::Option<std::string> level(op, "l", "log-level", "NONE", "level", "The minimum level for displaying log messages locally");
 	eudaq::Option<std::string> op_trace(op, "t", "tracefile", "", "filename", "Log file for tracing USB access");
-	try {
+        eudaq::Option<std::string> name (op, "n", "name", "TLU", "string", "The name of this Producer");
+
+        try {
 		op.Parse(argv);
 		EUDAQ_LOG_LEVEL(level.Value());
 		if (op_trace.Value() != "") {
 			setusbtracefile(op_trace.Value());
 		}
-		TLUProducer producer(rctrl.Value());
+		TLUProducer producer(name.Value(), rctrl.Value());
 		producer.MainLoop();
 		std::cout << "Quitting" << std::endl;
 		eudaq::mSleep(300);


### PR DESCRIPTION
extending "native2" data type to match multiple data collectors DAQ scheme.
- additing ExampleTLUProducer (sends TLUEvents with system clocks for timestamps)
- changes to ExampleProducers - only ZeroSuppressed data sending (RAW commented out till next revision)
- factorisation of STARTRUN scripts
- bug fix in terminating GUI LogCollector