### PR TITLE
Swapped SetPMTVcntlMod and SetPMTVcntl

### DIFF
--- a/producers/tlu/src/TLUProducer.cxx
+++ b/producers/tlu/src/TLUProducer.cxx
@@ -130,8 +130,8 @@ public:
 				m_tlu->SelectDUT(param.Get("DUTInput", "DUTInput" + to_string(i), "RJ45"), 1 << i, false);
 			}
 			m_tlu->SetTriggerInterval(trigger_interval);
-			m_tlu->SetPMTVcntl(pmtvcntl, pmt_gain_error, pmt_offset_error);
 			m_tlu->SetPMTVcntlMod(pmtvcntlmod);
+			m_tlu->SetPMTVcntl(pmtvcntl, pmt_gain_error, pmt_offset_error);
 			m_tlu->SetDUTMask(dut_mask);
 			m_tlu->SetVetoMask(veto_mask);
 			m_tlu->SetAndMask(and_mask);


### PR DESCRIPTION
It's always a good idea to set a required flag before invoking a function that needs it... In this case, the flag indicating whether or not a TLU that has been modified to generate 0->2V Vcntl signals to the PMTs was being set after the Vcntl voltages, so it would fail if using a so-modified TLU. This bug had no impact unless the modified TLU feature was being used.