### PR TITLE
Update Travis CI build script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: cpp
 
 compiler:
-  - clang
+#  - clang
   - gcc
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,53 @@
 language: cpp
+
 compiler:
+  - clang
   - gcc
-before_install:
-# We need this line to have g++4.8 available in apt
-  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-  - sudo apt-get update -qq
-install:
-  - sudo apt-get install -qq gcc-4.8 g++-4.8 cmake qt4-dev-tools
-# We want to compile with g++ 4.8 when rather than the default g++
-  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
+
 branches:
   only:
-    - master
     - v1.4-dev
+
+os:
+  - linux
+  - osx
+
+before_install:
+  - echo $LANG
+  - echo $LC_ALL
+
+  # Linux: add toolchain repository and update:
+  - if [ $TRAVIS_OS_NAME == linux ]; then sudo apt-add-repository -y ppa:ubuntu-toolchain-r/test; fi
+  - if [ $TRAVIS_OS_NAME == linux ]; then sudo apt-get update; fi
+
+  # Linux: grab ROOT deb package since it's not in the repos for this Ubuntu version:
+  - if [ $TRAVIS_OS_NAME == linux ]; then sudo wget http://downloads.sourceforge.net/project/cernrootdebs/latest-recommended/root_5.34.07-1_amd64.deb; fi
+
+  # OS X: update brew cache:
+  - if [ $TRAVIS_OS_NAME == osx ]; then brew update; fi
+  
+install:
+  # Install package dependencies for Linux:
+  - if [ $TRAVIS_OS_NAME == linux ]; then sudo apt-get install -y libusb-1.0-0 libusb-1.0-0-dev python2.7 python-numpy gcc-4.8 g++-4.8 cmake qt4-dev-tools; fi
+
+  # Install ROOT on Linux:
+  - if [ $TRAVIS_OS_NAME == linux ]; then sudo dpkg --install root_5.34.07-1_amd64.deb && source /usr/local/bin/thisroot.sh; fi
+
+  # Install package dependencies for Mac OS X:
+  - if [ $TRAVIS_OS_NAME == osx ]; then brew install python libusb homebrew/science/root; fi
+  # Install numpy via pip:
+  - if [ $TRAVIS_OS_NAME == osx ]; then easy_install pip && pip install numpy; fi
+
 before_script:
- - cd build
- - cmake -DBUILD_onlinemon=OFF -DBUILD_offlinemon=OFF ..
+  # We want to compile with g++4.8 rather than the default g++
+  - if [ $TRAVIS_OS_NAME == linux ]; then sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90; fi
+
+  # For Mac OS X we still need to source the root environment:
+  - if [ $TRAVIS_OS_NAME == osx ]; then source $(brew --prefix root)/libexec/thisroot.sh; fi
+
+  - cd build
+
 script:
- - make
+ - cmake ..
+ - make install
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,11 @@ os:
   - osx
 
 before_install:
-  - echo $LANG
-  - echo $LC_ALL
-
   # Linux: add toolchain repository and update:
-  - if [ $TRAVIS_OS_NAME == linux ]; then sudo apt-add-repository -y ppa:ubuntu-toolchain-r/test; fi
+  # g++4.8.1
+  - if [ $TRAVIS_OS_NAME == linux && "$CXX" == "g++" ]; then sudo apt-add-repository -y ppa:ubuntu-toolchain-r/test; fi
+  # clang 3.4
+  - if [ $TRAVIS_OS_NAME == linux && "$CXX" == "clang++" ]; then sudo apt-add-repository -y ppa:h-rayflood/llvm; fi
   - if [ $TRAVIS_OS_NAME == linux ]; then sudo apt-get update; fi
 
   # Linux: grab ROOT deb package since it's not in the repos for this Ubuntu version:
@@ -28,7 +28,9 @@ before_install:
   
 install:
   # Install package dependencies for Linux:
-  - if [ $TRAVIS_OS_NAME == linux ]; then sudo apt-get install -y libusb-1.0-0 libusb-1.0-0-dev python2.7 python-numpy gcc-4.8 g++-4.8 cmake qt4-dev-tools; fi
+  - if [ $TRAVIS_OS_NAME == linux ]; then sudo apt-get install -y libusb-1.0-0 libusb-1.0-0-dev python2.7 python-numpy cmake qt4-dev-tools; fi
+  - if [ $TRAVIS_OS_NAME == linux && "$CXX" == "g++" ]; then sudo apt-get install -qq gcc-4.8 g++-4.8; fi
+  - if [ $TRAVIS_OS_NAME == linux && "$CXX" == "clang++" ]; then sudo apt-get install  --allow-unauthenticated -qq clang-3.4; fi
 
   # Install ROOT on Linux:
   - if [ $TRAVIS_OS_NAME == linux ]; then sudo dpkg --install root_5.34.07-1_amd64.deb && source /usr/local/bin/thisroot.sh; fi
@@ -40,7 +42,10 @@ install:
 
 before_script:
   # We want to compile with g++4.8 rather than the default g++
-  - if [ $TRAVIS_OS_NAME == linux ]; then sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90; fi
+  - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8"; fi
+  - if [ $TRAVIS_OS_NAME == linux && "$CXX" = "g++" ]; then sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90; fi
+  # Clang 3.4 build:
+  - if [ "$CXX" == "clang++" ]; then export CXX="clang++-3.4"; fi
 
   # For Mac OS X we still need to source the root environment:
   - if [ $TRAVIS_OS_NAME == osx ]; then source $(brew --prefix root)/libexec/thisroot.sh; fi
@@ -48,6 +53,7 @@ before_script:
   - cd build
 
 script:
- - cmake ..
- - make install
+  - $CXX --version
+  - cmake ..
+  - make install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ before_install:
   # Linux: add toolchain repository and update:
   # g++4.8.1
   - if [ $TRAVIS_OS_NAME == linux ] && [ "$CXX" == "g++" ]; then sudo apt-add-repository -y ppa:ubuntu-toolchain-r/test; fi
-  # clang 3.4
-  - if [ $TRAVIS_OS_NAME == linux ] && [ "$CXX" == "clang++" ]; then sudo apt-add-repository -y ppa:h-rayflood/llvm; fi
   - if [ $TRAVIS_OS_NAME == linux ]; then sudo apt-get update; fi
 
   # Linux: grab ROOT deb package since it's not in the repos for this Ubuntu version:
@@ -32,7 +30,6 @@ install:
   # Install package dependencies for Linux:
   - if [ $TRAVIS_OS_NAME == linux ]; then sudo apt-get install -y libusb-1.0-0 libusb-1.0-0-dev python2.7 python-numpy cmake qt4-dev-tools; fi
   - if [ $TRAVIS_OS_NAME == linux ] && [ "$CXX" == "g++" ]; then sudo apt-get install -qq gcc-4.8 g++-4.8; fi
-  - if [ $TRAVIS_OS_NAME == linux ] && [ "$CXX" == "clang++" ]; then sudo apt-get install  --allow-unauthenticated -qq clang-3.4; fi
 
   # Install ROOT on Linux:
   - if [ $TRAVIS_OS_NAME == linux ]; then sudo dpkg --install root_5.34.07-1_amd64.deb && source /usr/local/bin/thisroot.sh; fi
@@ -46,8 +43,6 @@ before_script:
   # We want to compile with g++4.8 rather than the default g++
   - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8"; fi
   - if [ $TRAVIS_OS_NAME == linux ] && [ "$CXX" = "g++" ]; then sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90; fi
-  # Clang 3.4 build:
-  - if [ "$CXX" == "clang++" ]; then export CXX="clang++-3.4"; fi
 
   # For Mac OS X we still need to source the root environment:
   - if [ $TRAVIS_OS_NAME == osx ]; then source $(brew --prefix root)/libexec/thisroot.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,9 @@ before_install:
 
   # Linux: add toolchain repository and update:
   # g++4.8.1
-  - if [ $TRAVIS_OS_NAME == linux && "$CXX" == "g++" ]; then sudo apt-add-repository -y ppa:ubuntu-toolchain-r/test; fi
+  - if [ $TRAVIS_OS_NAME == linux ] && [ "$CXX" == "g++" ]; then sudo apt-add-repository -y ppa:ubuntu-toolchain-r/test; fi
   # clang 3.4
-  - if [ $TRAVIS_OS_NAME == linux && "$CXX" == "clang++" ]; then sudo apt-add-repository -y ppa:h-rayflood/llvm; fi
+  - if [ $TRAVIS_OS_NAME == linux ] && [ "$CXX" == "clang++" ]; then sudo apt-add-repository -y ppa:h-rayflood/llvm; fi
   - if [ $TRAVIS_OS_NAME == linux ]; then sudo apt-get update; fi
 
   # Linux: grab ROOT deb package since it's not in the repos for this Ubuntu version:
@@ -31,8 +31,8 @@ before_install:
 install:
   # Install package dependencies for Linux:
   - if [ $TRAVIS_OS_NAME == linux ]; then sudo apt-get install -y libusb-1.0-0 libusb-1.0-0-dev python2.7 python-numpy cmake qt4-dev-tools; fi
-  - if [ $TRAVIS_OS_NAME == linux && "$CXX" == "g++" ]; then sudo apt-get install -qq gcc-4.8 g++-4.8; fi
-  - if [ $TRAVIS_OS_NAME == linux && "$CXX" == "clang++" ]; then sudo apt-get install  --allow-unauthenticated -qq clang-3.4; fi
+  - if [ $TRAVIS_OS_NAME == linux ] && [ "$CXX" == "g++" ]; then sudo apt-get install -qq gcc-4.8 g++-4.8; fi
+  - if [ $TRAVIS_OS_NAME == linux ] && [ "$CXX" == "clang++" ]; then sudo apt-get install  --allow-unauthenticated -qq clang-3.4; fi
 
   # Install ROOT on Linux:
   - if [ $TRAVIS_OS_NAME == linux ]; then sudo dpkg --install root_5.34.07-1_amd64.deb && source /usr/local/bin/thisroot.sh; fi
@@ -45,7 +45,7 @@ install:
 before_script:
   # We want to compile with g++4.8 rather than the default g++
   - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8"; fi
-  - if [ $TRAVIS_OS_NAME == linux && "$CXX" = "g++" ]; then sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90; fi
+  - if [ $TRAVIS_OS_NAME == linux ] && [ "$CXX" = "g++" ]; then sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90; fi
   # Clang 3.4 build:
   - if [ "$CXX" == "clang++" ]; then export CXX="clang++-3.4"; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ os:
   - osx
 
 before_install:
+  - echo $CXX
+
   # Linux: add toolchain repository and update:
   # g++4.8.1
   - if [ $TRAVIS_OS_NAME == linux && "$CXX" == "g++" ]; then sudo apt-add-repository -y ppa:ubuntu-toolchain-r/test; fi
@@ -53,7 +55,6 @@ before_script:
   - cd build
 
 script:
-  - $CXX --version
   - cmake ..
   - make install
 


### PR DESCRIPTION
this should allow us to run Travis CI automated builds again on v1.4-dev branch. Added some features (e.g. building of the python modules).

Deactivated Clang build for now because it has problems with finding STL headers onn the Ubuntu 12 machine the build is running on. To be investigated and solved.