### PR TITLE
OnlineMon & DataCollector fixes + CMSPixelProducer update

### DIFF
--- a/main/lib/src/DataCollector.cc
+++ b/main/lib/src/DataCollector.cc
@@ -139,6 +139,8 @@ namespace eudaq {
 
   void DataCollector::OnCompleteEvent() {
     bool more = true;
+    bool found_bore = false;
+
     while (more) {
       if (m_eventnumber < 10 || m_eventnumber % 1000 == 0) {
         std::cout << "Complete Event: " << m_runnumber << "." << m_eventnumber << std::endl;
@@ -176,6 +178,7 @@ namespace eudaq {
       if (ev.IsBORE()) {
         ev.SetTag("STARTTIME", m_runstart.Formatted());
         ev.SetTag("CONFIG", to_string(m_config));
+	found_bore = true;
       }
       if (ev.IsEORE()) {
         ev.SetTag("STOPTIME", Time::Current().Formatted());
@@ -193,8 +196,11 @@ namespace eudaq {
       } else {
         EUDAQ_ERROR("Event received before start of run");
       }
-      //std::cout << ev << std::endl;
-      ++m_eventnumber;
+
+      // Only increase the internal event counter for non-BORE events.
+      // This is required since all producers start sending data with event ID 0
+      // but the data collector would already be at 1, since BORE was 0.
+      if(!found_bore) ++m_eventnumber;
     }
   }
 

--- a/main/lib/src/FileSerializer.cc
+++ b/main/lib/src/FileSerializer.cc
@@ -47,6 +47,16 @@ namespace eudaq {
   {
     m_file = fopen(fname.c_str(), "rb");
     if (!m_file) EUDAQ_THROWX(FileNotFoundException, "Unable to open file: " + fname);
+    // check if the file actually contains data. otherwise it will hang
+    // later on while trying to sync the events
+    if (fseek(m_file, 0L, SEEK_END) != 0) {
+        EUDAQ_THROWX(FileReadException, "seek to end failed: " + fname);
+    }
+    // go back to the beginning of the file
+    if (fseek(m_file, 0L, SEEK_SET) != 0) {
+        EUDAQ_THROWX(FileReadException, "seek to begin failed: " + fname);
+    }
+
   }
 
   bool FileDeserializer::HasData() {

--- a/main/lib/src/FileSerializer.cc
+++ b/main/lib/src/FileSerializer.cc
@@ -47,18 +47,6 @@ namespace eudaq {
   {
     m_file = fopen(fname.c_str(), "rb");
     if (!m_file) EUDAQ_THROWX(FileNotFoundException, "Unable to open file: " + fname);
-    // check if the file actually contains data. otherwise it will hang
-    // later on while trying to sync the events
-    if (fseek(m_file, 0L, SEEK_END) != 0) {
-        EUDAQ_THROWX(FileReadException, "seek to end failed: " + fname);
-    }
-    if (ftell(m_file) == 0) {
-        EUDAQ_THROWX(FileReadException, "file is empty: " + fname);
-    }
-    // go back to the beginning of the file
-    if (fseek(m_file, 0L, SEEK_SET) != 0) {
-        EUDAQ_THROWX(FileReadException, "seek to begin failed: " + fname);
-    }
   }
 
   bool FileDeserializer::HasData() {

--- a/monitors/onlinemon/include/OnlineMon.hh
+++ b/monitors/onlinemon/include/OnlineMon.hh
@@ -76,6 +76,7 @@ class RootMonitor : private eudaq::Holder<int>,
       int _offline;
       CheckEOF _checkEOF;
 
+      bool _planesInitialized;
       //bool _autoReset;
 
     public:

--- a/monitors/onlinemon/src/OnlineMon.cxx
+++ b/monitors/onlinemon/src/OnlineMon.cxx
@@ -52,7 +52,7 @@ using namespace std;
 RootMonitor::RootMonitor(const std::string & runcontrol, const std::string & datafile, int /*x*/, int /*y*/, int /*w*/,
 			 int /*h*/, int argc, int offline, const unsigned lim, const unsigned skip_, const unsigned int skip_with_counter,
 			 const std::string & conffile)
-: eudaq::Holder<int>(argc), eudaq::Monitor("OnlineMon", runcontrol, lim, skip_, skip_with_counter, datafile), _offline(offline){
+  : eudaq::Holder<int>(argc), eudaq::Monitor("OnlineMon", runcontrol, lim, skip_, skip_with_counter, datafile), _offline(offline), _planesInitialized(false) {
 
   if (_offline <= 0)
   {
@@ -217,15 +217,14 @@ void RootMonitor::OnEvent(const eudaq::StandardEvent & ev) {
   if (reduce)
   {
     unsigned int num = (unsigned int) ev.NumPlanes();
-    // some simple consistency checks
-    if (ev.GetEventNumber() < 1)
-    {
+    // Initialize the geometry with the first event received:
+    if(!_planesInitialized) {
       myevent.setNPlanes(num);
+      _planesInitialized = true;
+      std::cout << "Initialized geometry." << std::endl;
     }
-    else
-    {
-      if (myevent.getNPlanes()!=num)
-      {
+    else {
+      if (myevent.getNPlanes()!=num) {
 
         cout << "Plane Mismatch on " <<ev.GetEventNumber()<<endl;
         cout << "Current/Previous " <<num<<"/"<<myevent.getNPlanes()<<endl;
@@ -235,8 +234,7 @@ void RootMonitor::OnEvent(const eudaq::StandardEvent & ev) {
         EUDAQ_LOG(WARN,(eudaq_warn_message.str()).c_str());
 
       }
-      else
-      {
+      else {
         myevent.setNPlanes(num);
       }
     }

--- a/producers/cmspixel/include/CMSPixelProducer.hh
+++ b/producers/cmspixel/include/CMSPixelProducer.hh
@@ -32,8 +32,6 @@ private:
   void ReadInFullBufferWriteBinary();
   void ReadInFullBufferWriteASCII();
 
-  // Helper function to read DACs from the eudaq config object:
-  std::vector<std::pair<std::string,uint8_t> > GetConfDACs();
   // Helper function to read DACs from file which is provided via eudaq config:
   std::vector<std::pair<std::string,uint8_t> > GetConfDACs(std::string filename);
 
@@ -43,7 +41,7 @@ private:
   unsigned m_tlu_waiting_time;
   std::string m_verbosity, m_foutName, m_roctype, m_pcbtype, m_usbId, m_producerName, m_detector, m_event_type, m_alldacs;
   bool m_terminated, m_running, triggering;
-  bool m_dacsFromConf, m_trimmingFromConf, m_trigger_is_pg;
+  bool m_trimmingFromConf, m_trigger_is_pg;
   eudaq::Configuration m_config;
 
   // Add one mutex to protect calls to pxarCore:

--- a/producers/cmspixel/src/CMSPixelProducer.cxx
+++ b/producers/cmspixel/src/CMSPixelProducer.cxx
@@ -39,7 +39,6 @@ CMSPixelProducer::CMSPixelProducer(const std::string & name, const std::string &
     m_running(false),
     m_api(NULL),
     m_verbosity(verbosity),
-    m_dacsFromConf(false),
     m_trimmingFromConf(false),
     m_pattern_delay(0),
     m_trigger_is_pg(false),
@@ -128,10 +127,8 @@ void CMSPixelProducer::OnConfigure(const eudaq::Configuration & config) {
     else { trimFile = config.Get("trimDir", "") + string("/trimParameters.dat"); }
     rocPixels.push_back(GetConfTrimming(trimFile));
 
-    // If a DAC file is provided we read the DAC settings from there:
-    if(config.Get("dacFile", "") != "") { rocDACs.push_back(GetConfDACs(config.Get("dacFile", ""))); }
-    // If no file is provided, we try to use the DACs defined in the config file directly:
-    else { rocDACs.push_back(GetConfDACs()); }
+    // Read the DAC file, but update the vector with single DAC settings provided in the config:
+    rocDACs.push_back(GetConfDACs(config.Get("dacFile", "")));
 
     // Set the type of the ROC correctly:
     m_roctype = config.Get("roctype","psi46digv2");
@@ -220,8 +217,6 @@ void CMSPixelProducer::OnConfigure(const eudaq::Configuration & config) {
     std::cout << "Current DAC settings:" << std::endl;
     m_api->_dut->printDACs(0);
 
-    /*if(!m_dacsFromConf)
-      SetStatus(eudaq::Status::LVL_WARN, "Couldn't read all DAC parameters from config file " + config.Name() + ".");*/
     if(!m_trimmingFromConf)
       SetStatus(eudaq::Status::LVL_WARN, "Couldn't read all trimming parameters from config file " + config.Name() + ".");
     else


### PR DESCRIPTION
Fixes some bugs in Online monitor enabling direct running from RunControl again.
Fixes some bugs in DataCollector enabling Online Monitoring of data taken without TLU.

Changes the behaviour of CMSPixelProducer when reading DACs.