### PR TITLE
Fixes to OnlineMonitor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,13 @@ SET(CMAKE_INSTALL_PREFIX "${INSTALL_PREFIX}" CACHE INTERNAL "Prefix prepended to
 # optional debug defines
 # add_definitions("-DDEBUG_NOTIMEOUT=1 -DDEBUG_TRANSPORT=1")
 
+# Set the correct build type and allow command line options:
+# Set a default build type if none was specified
+IF(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  MESSAGE(STATUS "Setting build type to 'RelWithDebInfo' as none was specified.")
+  SET(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING "Choose the type of build." FORCE)
+ENDIF()
+
 # include directories
 INCLUDE_DIRECTORIES( ./main/include )
 INCLUDE_DIRECTORIES( ./extern/jsoncons-0.93/src )

--- a/monitors/onlinemon/include/HitmapHistos.hh
+++ b/monitors/onlinemon/include/HitmapHistos.hh
@@ -30,6 +30,8 @@ class HitmapHistos {
     int _maxY;
     bool _wait;
     TH2I * _hitmap;
+    TH1I * _hitXmap;
+    TH1I * _hitYmap;
     TH2I * _clusterMap;
     TH2D * _HotPixelMap;
     TH1I * _lvl1Distr;
@@ -67,6 +69,8 @@ class HitmapHistos {
 
 
     TH2I * getHitmapHisto() { return _hitmap; }
+    TH1I * getHitXmapHisto() { return _hitXmap; }
+    TH1I * getHitYmapHisto() { return _hitYmap; }
     TH1I * getHitmapSectionsHisto() { return _hitmapSections; }
     TH2I * getClusterMapHisto() { return _clusterMap; }
     TH2D * getHotPixelMapHisto() { return _HotPixelMap; }

--- a/monitors/onlinemon/src/EUDAQMonitorCollection.cc
+++ b/monitors/onlinemon/src/EUDAQMonitorCollection.cc
@@ -30,7 +30,7 @@ void EUDAQMonitorCollection::fillHistograms(const SimpleStandardEvent & ev)
 
 void EUDAQMonitorCollection::Reset()
 {
-  mymonhistos->Reset();
+  if(mymonhistos != NULL) mymonhistos->Reset();
 }
 
 

--- a/monitors/onlinemon/src/HitmapCollection.cc
+++ b/monitors/onlinemon/src/HitmapCollection.cc
@@ -192,6 +192,13 @@ void HitmapCollection::registerPlane(const SimpleStandardPlane &p) {
 #endif
     _mon->getOnlineMon()->addTreeItemSummary(folder,tree);
 
+    sprintf(tree,"%s/Sensor %i/Hitmap X Projection",p.getName().c_str(),p.getID());
+    _mon->getOnlineMon()->registerTreeItem(tree);
+    _mon->getOnlineMon()->registerHisto(tree,getHitmapHistos(p.getName(),p.getID())->getHitXmapHisto());
+
+    sprintf(tree,"%s/Sensor %i/Hitmap Y Projection",p.getName().c_str(),p.getID());
+    _mon->getOnlineMon()->registerTreeItem(tree);
+    _mon->getOnlineMon()->registerHisto(tree,getHitmapHistos(p.getName(),p.getID())->getHitYmapHisto());
 
     sprintf(tree,"%s/Sensor %i/Clustermap",p.getName().c_str(),p.getID());
     _mon->getOnlineMon()->registerTreeItem(tree);

--- a/monitors/onlinemon/src/HitmapHistos.cc
+++ b/monitors/onlinemon/src/HitmapHistos.cc
@@ -52,12 +52,12 @@ HitmapHistos::HitmapHistos(SimpleStandardPlane p, RootMonitor* mon): _sensor(p.g
 
     sprintf(out,"%s %i Raw Hitmap X-Projection",_sensor.c_str(), _id);
     sprintf(out2,"h_hitXmap_%s_%i",_sensor.c_str(), _id);
-    _hitXmap = new TH1I(out2, out,_maxX+1,0,_max);
+    _hitXmap = new TH1I(out2, out,_maxX+1,0,_maxX);
     SetHistoAxisLabelx(_clusterSize,"X");
 
     sprintf(out,"%s %i Raw Hitmap Y-Projection",_sensor.c_str(), _id);
     sprintf(out2,"h_hitYmap_%s_%i",_sensor.c_str(), _id);
-    _hitYmap = new TH1I(out2, out,_maxY+1,0,_maxY,);
+    _hitYmap = new TH1I(out2, out,_maxY+1,0,_maxY);
     SetHistoAxisLabelx(_clusterSize,"Y");
 
     sprintf(out,"%s %i Cluster Hitmap",_sensor.c_str(),_id);

--- a/monitors/onlinemon/src/HitmapHistos.cc
+++ b/monitors/onlinemon/src/HitmapHistos.cc
@@ -53,12 +53,12 @@ HitmapHistos::HitmapHistos(SimpleStandardPlane p, RootMonitor* mon): _sensor(p.g
     sprintf(out,"%s %i Raw Hitmap X-Projection",_sensor.c_str(), _id);
     sprintf(out2,"h_hitXmap_%s_%i",_sensor.c_str(), _id);
     _hitXmap = new TH1I(out2, out,_maxX+1,0,_maxX);
-    SetHistoAxisLabelx(_clusterSize,"X");
+    SetHistoAxisLabelx(_hitXmap,"X");
 
     sprintf(out,"%s %i Raw Hitmap Y-Projection",_sensor.c_str(), _id);
     sprintf(out2,"h_hitYmap_%s_%i",_sensor.c_str(), _id);
     _hitYmap = new TH1I(out2, out,_maxY+1,0,_maxY);
-    SetHistoAxisLabelx(_clusterSize,"Y");
+    SetHistoAxisLabelx(_hitYmap,"Y");
 
     sprintf(out,"%s %i Cluster Hitmap",_sensor.c_str(),_id);
     sprintf(out2,"h_clustermap_%s_%i",_sensor.c_str(), _id);

--- a/monitors/onlinemon/src/HitmapHistos.cc
+++ b/monitors/onlinemon/src/HitmapHistos.cc
@@ -10,7 +10,7 @@
 #include <cstdlib>
 
 HitmapHistos::HitmapHistos(SimpleStandardPlane p, RootMonitor* mon): _sensor(p.getName()), _id(p.getID()), _maxX(p.getMaxX()), _maxY(p.getMaxY()), _wait(false),
-  _hitmap(NULL),_clusterMap(NULL),_lvl1Distr(NULL), _lvl1Width(NULL),_lvl1Cluster(NULL),_totSingle(NULL),_totCluster(NULL),
+								     _hitmap(NULL),_hitXmap(NULL),_hitYmap(NULL),_clusterMap(NULL),_lvl1Distr(NULL), _lvl1Width(NULL),_lvl1Cluster(NULL),_totSingle(NULL),_totCluster(NULL),
   _hitOcc(NULL), _nClusters(NULL), _nHits(NULL), _clusterXWidth(NULL), _clusterYWidth(NULL),_nbadHits(NULL),_nHotPixels(NULL),_hitmapSections(NULL),
   is_MIMOSA26(false), is_APIX(false), is_USBPIX(false),is_USBPIXI4(false)
 {
@@ -49,6 +49,16 @@ HitmapHistos::HitmapHistos(SimpleStandardPlane p, RootMonitor* mon): _sensor(p.g
     _hitmap = new TH2I(out2, out, _maxX+1,0,_maxX, _maxY+1,0,_maxY);
     SetHistoAxisLabels(_hitmap,"X","Y");
     //std::cout << "Created Histogram " << out2 << std::endl;
+
+    sprintf(out,"%s %i Raw Hitmap X-Projection",_sensor.c_str(), _id);
+    sprintf(out2,"h_hitXmap_%s_%i",_sensor.c_str(), _id);
+    _hitXmap = new TH1I(out2, out,_maxX+1,0,_max);
+    SetHistoAxisLabelx(_clusterSize,"X");
+
+    sprintf(out,"%s %i Raw Hitmap Y-Projection",_sensor.c_str(), _id);
+    sprintf(out2,"h_hitYmap_%s_%i",_sensor.c_str(), _id);
+    _hitYmap = new TH1I(out2, out,_maxY+1,0,_maxY,);
+    SetHistoAxisLabelx(_clusterSize,"Y");
 
     sprintf(out,"%s %i Cluster Hitmap",_sensor.c_str(),_id);
     sprintf(out2,"h_clustermap_%s_%i",_sensor.c_str(), _id);
@@ -257,6 +267,8 @@ void HitmapHistos::Fill(const SimpleStandardHit & hit)
   if (_HotPixelMap->GetBinContent(pixel_x+1,pixel_y+1)>_mon->mon_configdata.getHotpixelcut()) pixelIsHot=true;
 
   if (_hitmap != NULL && !pixelIsHot) _hitmap->Fill(pixel_x,pixel_y);
+  if (_hitXmap != NULL && !pixelIsHot) _hitXmap->Fill(pixel_x);
+  if (_hitYmap != NULL && !pixelIsHot) _hitYmap->Fill(pixel_y);
   if ((is_MIMOSA26) && (_hitmapSections != NULL) && (!pixelIsHot))
     //&& _hitOcc->GetEntries()>0) // only fill histogram when occupancies and hotpixels have been determined
   {
@@ -360,6 +372,8 @@ void HitmapHistos::Fill(const SimpleStandardCluster & cluster)
 
 void HitmapHistos::Reset() {
   _hitmap->Reset();
+  _hitXmap->Reset();
+  _hitYmap->Reset();
   _totSingle->Reset();
   _lvl1Distr->Reset();
   _clusterMap->Reset();
@@ -462,6 +476,8 @@ void HitmapHistos::Calculate(const int currentEventNum)
 void HitmapHistos::Write()
 {
   _hitmap->Write();
+  _hitXmap->Write();
+  _hitYmap->Write();
   _totSingle->Write();
   _lvl1Distr->Write();
   _clusterMap->Write();

--- a/monitors/onlinemon/src/OnlineMon.cxx
+++ b/monitors/onlinemon/src/OnlineMon.cxx
@@ -220,7 +220,7 @@ void RootMonitor::OnEvent(const eudaq::StandardEvent & ev) {
     // Initialize the geometry with the first event received:
     if(!_planesInitialized) {
       myevent.setNPlanes(num);
-      std::cout << "Initialized geometry." << std::endl;
+      std::cout << "Initialized geometry: " << num << " planes." << std::endl;
     }
     else {
       if (myevent.getNPlanes()!=num) {

--- a/monitors/onlinemon/src/OnlineMon.cxx
+++ b/monitors/onlinemon/src/OnlineMon.cxx
@@ -220,7 +220,6 @@ void RootMonitor::OnEvent(const eudaq::StandardEvent & ev) {
     // Initialize the geometry with the first event received:
     if(!_planesInitialized) {
       myevent.setNPlanes(num);
-      _planesInitialized = true;
       std::cout << "Initialized geometry." << std::endl;
     }
     else {
@@ -347,7 +346,7 @@ void RootMonitor::OnEvent(const eudaq::StandardEvent & ev) {
     my_event_inner_operations_time.Stop();
     previous_event_clustering_time = my_event_inner_operations_time.RealTime();
 
-    if (ev.GetEventNumber() < 1)
+    if(!_planesInitialized)
     {
 #ifdef DEBUG
       cout << "Waiting for booking of Histograms..." << endl;
@@ -356,6 +355,7 @@ void RootMonitor::OnEvent(const eudaq::StandardEvent & ev) {
 #ifdef DEBUG
       cout << "...long enough"<< endl;
 #endif
+      _planesInitialized = true;
     }
 
     //stop the Stop watch
@@ -457,6 +457,9 @@ void RootMonitor::OnStartRun(unsigned param) {
     onlinemon->setRunNumber(runnumber);
     onlinemon->setRootFileName(rootfilename);
   }
+
+  // Reset the planes initializer on new run start:
+  _planesInitialized = false;
 
   SetStatus(eudaq::Status::LVL_OK);
 }


### PR DESCRIPTION
  * Fix crash if nPlanes change between two runs (e.g. added new producer and reconfigured)
  * Fix crash when "AutoReset" was activated before first run was started
  * Add new projected hitmap histograms