### PR TITLE
Added lcio requirement/headers/library to nreader as otherwise eudaq …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,14 +90,15 @@ option(BUILD_nreader "Compile native reader shared library (requires LCIO/EUTele
 IF(BUILD_nreader)
   SET(USE_LCIO ON)
   FIND_PACKAGE(EUTelescope REQUIRED)
-  INCLUDE_DIRECTORIES(${EUTELESCOPE_INCLUDE_DIRS} ${PROJECT_SOURCE_DIR}/nreader/include)
-  add_definitions(${EUTELESCOPE_DEFINITIONS})
+  FIND_PACKAGE(LCIO REQUIRED)
+  INCLUDE_DIRECTORIES(${LCIO_INCLUDE_DIRS} ${EUTELESCOPE_INCLUDE_DIRS} ${PROJECT_SOURCE_DIR}/nreader/include)
+  add_definitions(${LCIO_DEFINITIONS} ${EUTELESCOPE_DEFINITIONS})
   AUX_SOURCE_DIRECTORY( ${PROJECT_SOURCE_DIR}/nreader/detdescription detdescr_library_sources )
   ADD_LIBRARY( DetectorDescriptons SHARED ${detdescr_library_sources} )
   INSTALL(TARGETS DetectorDescriptons RUNTIME DESTINATION bin
                                       LIBRARY DESTINATION lib
                                       ARCHIVE DESTINATION lib)
-  set(ADDITIONAL_LIBRARIES ${EUTELESCOPE_LIBRARIES} DetectorDescriptons)
+  set(ADDITIONAL_LIBRARIES ${LCIO_LIBRARIES} ${EUTELESCOPE_LIBRARIES} DetectorDescriptons)
 ENDIF()
 
 find_package(Protobuf)


### PR DESCRIPTION
…compilation aborts with a missing lcio.h when using ilcsoft_install. This happens when the combination of eutelescope trunk and eudaq trunk is used due to the split between eutelescope and lcio requirements. 
[error_compiling_eutelescope_eudaq_lcio.txt](https://github.com/eudaq/eudaq/files/31892/error_compiling_eutelescope_eudaq_lcio.txt)

This was also observed by other people when doing e.g. an eutelescope installation on lxplus. I think that this report https://eutelescope.web.cern.ch/forum/eudaq-compilation is related.
```
-- Build files have been written to: /home/rummler/Software/eutelescope/installed_v011703/v01-17-05/Eutelescope/trunk/external/eudaq/trunk/build
Scanning dependencies of target DetectorDescriptons
[  0%] Building CXX object CMakeFiles/DetectorDescriptons.dir/nreader/detdescription/EUTelTakiDetector.cc.o
In file included from /home/rummler/Software/eutelescope/installed_v011703/v01-17-05/Eutelescope/trunk/include/EUTelROI.h:14:0,
                 from /home/rummler/Software/eutelescope/installed_v011703/v01-17-05/Eutelescope/trunk/external/eudaq/trunk/nreader/include/EUTelPixelDetector.h:8,
                 from /home/rummler/Software/eutelescope/installed_v011703/v01-17-05/Eutelescope/trunk/external/eudaq/trunk/nreader/include/EUTelTakiDetector.h:7,
                 from /home/rummler/Software/eutelescope/installed_v011703/v01-17-05/Eutelescope/trunk/external/eudaq/trunk/nreader/detdescription/EUTelTakiDetector.cc:4:
/home/rummler/Software/eutelescope/installed_v011703/v01-17-05/Eutelescope/trunk/include/EUTelExceptions.h:18:18: fatal error: lcio.h: No such file or directory
 #include <lcio.h>
```
