### PR TITLE
Fix compilation error with ROOT6. The histogram bit TH1::kCanRebin ha…

### DIFF
--- a/cmake/FindROOT.cmake
+++ b/cmake/FindROOT.cmake
@@ -87,9 +87,13 @@ ELSE(WIN32)
     STRING(REGEX REPLACE "^[0-9]+\\.[0-9][0-9]+\\/([0-9][0-9]+).*" "\\1" found_root_patch_vers "${ROOTVERSION}")
 
     IF (found_root_major_vers LESS 5)
-      MESSAGE( FATAL_ERROR "Invalid ROOT version \"${ROOTERSION}\", at least major version 4 is required, e.g. \"5.00/00\"")
+      MESSAGE( FATAL_ERROR "Invalid ROOT version \"${ROOTVERSION}\", at least major version 4 is required, e.g. \"5.00/00\"")
     ENDIF (found_root_major_vers LESS 5)
 
+    IF (found_root_major_vers EQUAL 6)
+      add_definitions(-DEUDAQ_LIB_ROOT6)
+    ENDIF (found_root_major_vers EQUAL 6)
+    
     # compute an overall version number which can be compared at once
     MATH(EXPR req_vers "${req_root_major_vers}*10000 + ${req_root_minor_vers}*100 + ${req_root_patch_vers}")
     MATH(EXPR found_vers "${found_root_major_vers}*10000 + ${found_root_minor_vers}*100 + ${found_root_patch_vers}")
@@ -105,7 +109,7 @@ ELSE(WIN32)
 
 
   IF (ROOT_FOUND)
-
+    
     # ask root-config for the library dir
     # Set ROOT_LIBRARY_DIR
 

--- a/monitors/onlinemon/src/EUDAQMonitorHistos.cc
+++ b/monitors/onlinemon/src/EUDAQMonitorHistos.cc
@@ -23,9 +23,14 @@ EUDAQMonitorHistos::EUDAQMonitorHistos(const SimpleStandardEvent &ev) {
   TracksPerEvent =
       new TProfile("Tracks per Event", "Tracks per Event", 1000, 0, 20000);
 
+#ifdef EUDAQ_LIB_ROOT6
+  Hits_vs_EventsTotal->SetCanExtend(TH1::kAllAxes);
+  TracksPerEvent->SetCanExtend(TH1::kAllAxes);
+#else
   Hits_vs_EventsTotal->SetBit(TH1::kCanRebin);
   TracksPerEvent->SetBit(TH1::kCanRebin);
-
+#endif
+  
   for (unsigned int i = 0; i < nplanes; i++) {
 
     stringstream number;
@@ -57,8 +62,14 @@ EUDAQMonitorHistos::EUDAQMonitorHistos(const SimpleStandardEvent &ev) {
       TLUdelta_perEventHisto[i]->SetLineColor(i + 2);
       TLUdelta_perEventHisto[i]->SetMarkerColor(i + 2);
     }
+
+#ifdef EUDAQ_LIB_ROOT6
+    Hits_vs_Events[i]->SetCanExtend(TH1::kAllAxes);
+    TLUdelta_perEventHisto[i]->SetCanExtend(TH1::kAllAxes);
+#else
     Hits_vs_Events[i]->SetBit(TH1::kCanRebin);
     TLUdelta_perEventHisto[i]->SetBit(TH1::kCanRebin);
+#endif
   }
 }
 


### PR DESCRIPTION
Fix compilation error with ROOT6. The histogram bit TH1::kCanRebin has been removed in ROOT6.
