### PR TITLE
LogCollector: allow specification of the logging directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,6 +227,14 @@ add_subdirectory(producers)
 ############################################### #######
 include(PrintSystemInformation)
 
+# uninstall target
+configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/uninstall.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+    IMMEDIATE @ONLY)
+
+add_custom_target(uninstall
+    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
 
 ###############################################
 # Python-based regression tests

--- a/cmake/uninstall.cmake.in
+++ b/cmake/uninstall.cmake.in
@@ -1,0 +1,21 @@
+if(NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+  message(FATAL_ERROR "Cannot find install manifest: @CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+endif(NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+
+file(READ "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt" files)
+string(REGEX REPLACE "\n" ";" files "${files}")
+foreach(file ${files})
+  message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
+  if(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    exec_program(
+      "@CMAKE_COMMAND@" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
+      OUTPUT_VARIABLE rm_out
+      RETURN_VALUE rm_retval
+      )
+    if(NOT "${rm_retval}" STREQUAL 0)
+      message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")
+    endif(NOT "${rm_retval}" STREQUAL 0)
+  else(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    message(STATUS "File $ENV{DESTDIR}${file} does not exist.")
+  endif(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+endforeach(file)

--- a/gui/include/euLog.hh
+++ b/gui/include/euLog.hh
@@ -29,11 +29,14 @@ class LogCollectorGUI : public QMainWindow,
   Q_OBJECT
 public:
   LogCollectorGUI(const std::string &runcontrol,
-                  const std::string &listenaddress, QRect geom,
-                  const std::string &filename, int loglevel,
+                  const std::string &listenaddress,
+		  const std::string &directory,
+		  QRect geom,
+                  const std::string &filename,
+		  int loglevel,
                   QWidget *parent = 0, Qt::WindowFlags flags = 0)
       : QMainWindow(parent, flags),
-        eudaq::LogCollector(runcontrol, listenaddress), m_delegate(&m_model) {
+        eudaq::LogCollector(runcontrol, listenaddress, directory), m_delegate(&m_model) {
     setupUi(this);
     viewLog->setModel(&m_model);
     viewLog->setItemDelegate(&m_delegate);

--- a/gui/src/euLog.cc
+++ b/gui/src/euLog.cc
@@ -14,6 +14,8 @@ int main(int argc, char **argv) {
   eudaq::Option<std::string> addr(
       op, "a", "listen-address", "tcp://44002", "address",
       "The address on which to listen for Log connections");
+  eudaq::Option<std::string> directory (op, "d", "directory", "../logs", "directory",
+				   "The path in which the log files should be stored");
   eudaq::Option<std::string> level(
       op, "l", "log-level", "INFO", "level",
       "The initial level for displaying log messages");
@@ -28,7 +30,7 @@ int main(int argc, char **argv) {
     op.Parse(argv);
     EUDAQ_LOG_LEVEL(level.Value());
     QRect rect(x.Value(), y.Value(), w.Value(), h.Value());
-    LogCollectorGUI gui(rctrl.Value(), addr.Value(), rect, file.Value(),
+    LogCollectorGUI gui(rctrl.Value(), addr.Value(), directory.Value(), rect, file.Value(),
                         eudaq::Status::String2Level(level.Value()));
     gui.show();
     return app.exec();

--- a/main/exe/src/TestLogCollector.cxx
+++ b/main/exe/src/TestLogCollector.cxx
@@ -13,9 +13,10 @@
 class TestLogCollector : public eudaq::LogCollector {
   public:
     TestLogCollector(const std::string & runcontrol,
-        const std::string & listenaddress,
-        int loglevel)
-      : eudaq::LogCollector(runcontrol, listenaddress),
+		     const std::string & listenaddress,
+		     const std::string & directory,
+		     int loglevel)
+      : eudaq::LogCollector(runcontrol, listenaddress, directory),
       m_loglevel(loglevel), done(false)
   {}
     void OnConnect(const eudaq::ConnectionInfo & id) override{
@@ -76,6 +77,8 @@ int main(int /*argc*/, const char ** argv) {
       "The address of the RunControl application");
   eudaq::Option<std::string> addr (op, "a", "listen-address", "tcp://44002", "address",
       "The address on which to listen for Log connections");
+  eudaq::Option<std::string> directory (op, "d", "directory", "logs", "directory",
+				   "The path in which the log files should be stored");
   eudaq::Option<std::string> level(op, "l", "log-level", "INFO", "level",
       "The minimum level for displaying log messages");
   eudaq::mSleep(2000);
@@ -83,7 +86,7 @@ int main(int /*argc*/, const char ** argv) {
     op.Parse(argv);
     EUDAQ_LOG_LEVEL("NONE");
     std::cout << "Log Collector  Connected to \"" << rctrl.Value() << "\"" << std::endl;
-    TestLogCollector fw(rctrl.Value(), addr.Value(), eudaq::Status::String2Level(level.Value()));
+    TestLogCollector fw(rctrl.Value(), addr.Value(), directory.Value(), eudaq::Status::String2Level(level.Value()));
     //g_ptr = &fw;
     //std::signal(SIGINT, &ctrlc_handler);
     do {

--- a/main/include/eudaq/LogCollector.hh
+++ b/main/include/eudaq/LogCollector.hh
@@ -21,7 +21,8 @@ namespace eudaq {
   class DLLEXPORT LogCollector : public CommandReceiver {
   public:
     LogCollector(const std::string &runcontrol,
-                 const std::string &listenaddress);
+                 const std::string &listenaddress,
+		 const std::string & logdirectory = "../logs");
 
     virtual void OnConnect(const ConnectionInfo & /*id*/) {}
     virtual void OnDisconnect(const ConnectionInfo & /*id*/) {}

--- a/main/lib/src/LogCollector.cc
+++ b/main/lib/src/LogCollector.cc
@@ -20,16 +20,18 @@ namespace eudaq {
   } // anonymous namespace
 
   LogCollector::LogCollector(const std::string &runcontrol,
-                             const std::string &listenaddress)
+                             const std::string &listenaddress,
+			     const std::string &logdirectory)
       : CommandReceiver("LogCollector", "", runcontrol, false), m_done(false),
         m_listening(true),
         m_logserver(TransportFactory::CreateServer(listenaddress)),
-        m_filename("../logs/" + Time::Current().Formatted("%Y-%m-%d.log")),
+        m_filename(logdirectory + "/" + Time::Current().Formatted("%Y-%m-%d.log")),
         m_file(m_filename.c_str(), std::ios_base::app) {
     if (!m_file.is_open())
       EUDAQ_THROWX(FileWriteException, "Unable to open log file (" +
-                                           m_filename +
-                                           ") is there a logs directory?");
+		   m_filename +
+		   ") is there a logs directory?");
+    else std::cout << "LogCollector opened \"" << m_filename << "\" for logging." << std::endl;
     m_logserver->SetCallback(
         TransportCallback(this, &LogCollector::LogHandler));
     // pthread_attr_init(&m_threadattr);


### PR DESCRIPTION
With this commit it is possible to specify the log file output directory at startup of the LogCollector (both TestLogCollector and euLog). Defaults to old behavior ("../logs"). 

This is a first step towards removing all content directories from the EUDAQ source tree