### PR TITLE
EUDAQ interfacing LCIO via EUTel

### DIFF
--- a/main/lib/plugins/APIX-CT-ConverterPlugin.cc
+++ b/main/lib/plugins/APIX-CT-ConverterPlugin.cc
@@ -240,8 +240,6 @@ namespace eudaq {
 	setupDescription.push_back( new eutelescope::EUTelSetupDescription( currentDetector )) ;
 	}
 	
-	std::list<eutelescope::EUTelGenericSparsePixel*> tmphits;
-	
 	int cio=chip_id_offset;
 	if(m_nFeSensor[m_sensorids[sensor]]==3)cio=0;
 	zsDataEncoder["sensorID"] = m_sensorids[sensor] + sm + cio;
@@ -285,9 +283,8 @@ namespace eudaq {
 	      int ModuleID=m_sensorids[sensor]+chip_id_offset;
 	      int lvl1=hits[i].lv1;
 	      int ToT=hits[i].tot;
-	      eutelescope::EUTelGenericSparsePixel *thisHit = new eutelescope::EUTelGenericSparsePixel( col, row, ToT, lvl1);
+	      auto thisHit = eutelescope::EUTelGenericSparsePixel( col, row, ToT, lvl1);
 	      sparseFrame->addSparsePixel( thisHit );
-	      tmphits.push_back( thisHit );
 	      /*
 	      //ganged pixels bottom
 	      if (row==329){
@@ -420,9 +417,8 @@ namespace eudaq {
 	      {
 		int col = hits[i].col;
 		int row = hits[i].row;
-		eutelescope::EUTelGenericSparsePixel *thisHit = new eutelescope::EUTelGenericSparsePixel( col, row, hits[i].tot, hits[i].lv1);
+		auto thisHit = eutelescope::EUTelGenericSparsePixel( col, row, hits[i].tot, hits[i].lv1);
 		sparseFrame->addSparsePixel( thisHit );
-		tmphits.push_back( thisHit );
 	      }
 	      //int col=(1+m_fepos[hits[i].link])*NCOL-1-hits[i].col; //left or right on 2-chip module
 	      // eutelescope::EUTelGenericSparsePixel *thisHit = new eutelescope::EUTelGenericSparsePixel( col, row, hits[i].tot, hits[i].lv1);
@@ -435,11 +431,6 @@ namespace eudaq {
       
 	// write TrackerData object that contains info from one sensor to LCIO collection
 	zsDataCollection->push_back( zsFrame.release() );
-	
-	// clean up
-	for( std::list<eutelescope::EUTelGenericSparsePixel*>::iterator it = tmphits.begin(); it != tmphits.end(); it++ ){
-	  delete (*it);
-	}
       }
     }
     

--- a/main/lib/plugins/CcpdlfADCConverterPlugin.cc
+++ b/main/lib/plugins/CcpdlfADCConverterPlugin.cc
@@ -171,8 +171,6 @@ namespace eudaq {
             setupDescription.push_back( new eutelescope::EUTelSetupDescription( currentDetector )) ;
           }
 
-          std::list<eutelescope::EUTelGenericSparsePixel*> tmphits;
-
           zsDataEncoder["sensorID"] = ev_raw.GetID(chip) + chip_id_offset; // 30
           zsDataEncoder["sparsePixelType"] = eutelescope::kEUTelGenericSparsePixel;
 
@@ -213,16 +211,10 @@ namespace eudaq {
                std::cout<< "GetStandardSubEvent() broken data"<<std::endl;
                return false;
           }
-          eutelescope::EUTelGenericSparsePixel *thisHit = new eutelescope::EUTelGenericSparsePixel(53, 19, cnt_max-cnt_base, trigger_number);
+          auto thisHit = eutelescope::EUTelGenericSparsePixel(53, 19, cnt_max-cnt_base, trigger_number);
           sparseFrame->addSparsePixel( thisHit );
-          tmphits.push_back( thisHit );
           // write TrackerData object that contains info from one sensor to LCIO collection
           zsDataCollection->push_back( zsFrame.release() );
-
-          // clean up
-          for( std::list<eutelescope::EUTelGenericSparsePixel*>::iterator it = tmphits.begin(); it != tmphits.end(); it++ ){
-            delete (*it);
-          }
         }
 
         // add this collection to lcio event

--- a/main/lib/plugins/CcpdlfConverterPlugin.cc
+++ b/main/lib/plugins/CcpdlfConverterPlugin.cc
@@ -198,8 +198,6 @@ namespace eudaq {
             setupDescription.push_back( new eutelescope::EUTelSetupDescription( currentDetector )) ;
           }
 
-          std::list<eutelescope::EUTelGenericSparsePixel*> tmphits;
-
           zsDataEncoder["sensorID"] = ev_raw.GetID(chip) + chip_id_offset; // 30
           zsDataEncoder["sparsePixelType"] = eutelescope::kEUTelGenericSparsePixel;
 
@@ -245,9 +243,8 @@ namespace eudaq {
                         col=col-1;
                         row=113-row;
                     }
-                    eutelescope::EUTelGenericSparsePixel *thisHit = new eutelescope::EUTelGenericSparsePixel(row, col, 1, 1);
+                    auto thisHit = eutelescope::EUTelGenericSparsePixel(row, col, 1, 1);
                     sparseFrame->addSparsePixel( thisHit );
-                    tmphits.push_back( thisHit );
                 }
                 hit2=hit2>>1;
                 if ( (hit & 0x1) == 0x0){ 
@@ -261,20 +258,14 @@ namespace eudaq {
                         col=col-1;
                         row=113-row;
                     }
-                    eutelescope::EUTelGenericSparsePixel *thisHit = new eutelescope::EUTelGenericSparsePixel(row, col, 1, 1);
+                    auto thisHit = eutelescope::EUTelGenericSparsePixel(row, col, 1, 1);
                     sparseFrame->addSparsePixel( thisHit );
-                    tmphits.push_back( thisHit );
                 }
                 hit=hit>>1;
             }
           }
           // write TrackerData object that contains info from one sensor to LCIO collection
           zsDataCollection->push_back( zsFrame.release() );
-
-          // clean up
-          for( std::list<eutelescope::EUTelGenericSparsePixel*>::iterator it = tmphits.begin(); it != tmphits.end(); it++ ){
-            delete (*it);
-          }
         }
 
         // add this collection to lcio event

--- a/main/lib/plugins/DataConverterPlugin.cc
+++ b/main/lib/plugins/DataConverterPlugin.cc
@@ -56,7 +56,7 @@ namespace eudaq {
     for (size_t iPixel = 0; iPixel < plane.HitPixels(); ++iPixel) {
       eutelescope::EUTelGenericSparsePixel thisHit1(
           plane.GetX(iPixel), plane.GetY(iPixel), plane.GetPixel(iPixel), 0);
-      sparseFrame.addSparsePixel(&thisHit1);
+      sparseFrame.addSparsePixel(thisHit1);
     }
   }
 #endif // USE_EUTELESCOPE

--- a/main/lib/plugins/EUDRBConverterPlugin.cc
+++ b/main/lib/plugins/EUDRBConverterPlugin.cc
@@ -645,7 +645,7 @@ namespace eudaq {
             // streamlog_out ( DEBUG0 ) << ( *(sparsePixel.get() ) ) << endl;
 
             // now add this pixel to the sparse frame
-            sparseFrame->addSparsePixel( sparsePixel.get() );
+            sparseFrame->addSparsePixel( *sparsePixel.get() );
           } else {
             // the original X was on a marker column, so we don't
             // need to process this pixel any further and of course

--- a/main/lib/plugins/Mupix2ConverterPlugin.cc
+++ b/main/lib/plugins/Mupix2ConverterPlugin.cc
@@ -234,7 +234,7 @@ bool Mupix2ConverterPlugin::GetLCIOSubEvent(
     for (unsigned i = 0; i < ExtractNumberOfHits(raw_buffer); ++i) {
         ExtractHit(raw_buffer, i, col, row);
         EUTelGenericSparsePixel pixel(col, row, MUPIX2_FAKE_SIGNAL);
-        pixels->addSparsePixel(&pixel);
+        pixels->addSparsePixel(pixel);
     }
     
     // hand over ownership over the readout frame to the lcio collection

--- a/main/lib/plugins/Mupix3ConverterPlugin.cc
+++ b/main/lib/plugins/Mupix3ConverterPlugin.cc
@@ -236,7 +236,7 @@ bool Mupix3ConverterPlugin::GetLCIOSubEvent(
     for (unsigned i = 0; i < n_hits; ++i) {
         ExtractHit(raw_buffer, i, col, row);
         EUTelGenericSparsePixel pixel(col, row, MUPIX3_FAKE_SIGNAL);
-        pixels->addSparsePixel(&pixel);
+        pixels->addSparsePixel(pixel);
     }
     
     // hand over ownership over the readout frame to the lcio collection

--- a/main/lib/plugins/Mupix4ConverterPlugin.cc
+++ b/main/lib/plugins/Mupix4ConverterPlugin.cc
@@ -205,7 +205,7 @@ bool Mupix4ConverterPlugin::GetLCIOSubEvent(
             data.hit_row(i),
             data.hit_col(i),
             MUPIX4_SENSOR_BINARY_SIGNAL);
-        pixels->addSparsePixel(&pixel);
+        pixels->addSparsePixel(pixel);
     }
 
     // hand over ownership over the readout frame to the lcio collection

--- a/main/lib/plugins/NIConverterPlugin.cc
+++ b/main/lib/plugins/NIConverterPlugin.cc
@@ -529,7 +529,7 @@ namespace eudaq {
             // streamlog_out ( DEBUG0 ) << ( *(sparsePixel.get() ) ) << endl;
 
             // now add this pixel to the sparse frame
-            sparseFrame->addSparsePixel(sparsePixel.get());
+            sparseFrame->addSparsePixel(*sparsePixel.get());
           } else {
             // the original X was on a marker column, so we don't
             // need to process this pixel any further and of course

--- a/main/lib/plugins/PyBARConverterPlugin.cc
+++ b/main/lib/plugins/PyBARConverterPlugin.cc
@@ -336,8 +336,6 @@ namespace eudaq {
             setupDescription.push_back( new eutelescope::EUTelSetupDescription( currentDetector )) ;
           }
 
-          std::list<eutelescope::EUTelGenericSparsePixel*> tmphits;
-
           zsDataEncoder["sensorID"] = ev_raw.GetID(chip) + chip_id_offset + first_sensor_id; // formerly 14
           zsDataEncoder["sparsePixelType"] = eutelescope::kEUTelGenericSparsePixel;
 
@@ -366,26 +364,19 @@ namespace eudaq {
             } else {
               // First Hit
               if (getHitData(Word, false, Col, Row, ToT)) {
-               eutelescope::EUTelGenericSparsePixel *thisHit = new eutelescope::EUTelGenericSparsePixel( Col, Row, ToT, lvl1-1);
+                auto thisHit = eutelescope::EUTelGenericSparsePixel( Col, Row, ToT, lvl1-1);
                 sparseFrame->addSparsePixel( thisHit );
-                tmphits.push_back( thisHit );
               }
               // Second Hit
               if (getHitData(Word, true, Col, Row, ToT)) {
-               eutelescope::EUTelGenericSparsePixel *thisHit = new eutelescope::EUTelGenericSparsePixel( Col, Row, ToT, lvl1-1);
+                auto thisHit = eutelescope::EUTelGenericSparsePixel( Col, Row, ToT, lvl1-1);
                 sparseFrame->addSparsePixel( thisHit );
-                tmphits.push_back( thisHit );
               }
             }
           }
 
           // write TrackerData object that contains info from one sensor to LCIO collection
           zsDataCollection->push_back( zsFrame.release() );
-
-          // clean up
-          for( std::list<eutelescope::EUTelGenericSparsePixel*>::iterator it = tmphits.begin(); it != tmphits.end(); it++ ){
-            delete (*it);
-          }
         }
 
         // add this collection to lcio event

--- a/main/lib/plugins/USBPixI4ConverterPlugin.cc
+++ b/main/lib/plugins/USBPixI4ConverterPlugin.cc
@@ -575,15 +575,15 @@ class USBPixI4ConverterPlugin : public DataConverterPlugin , public USBPixI4Conv
 					if(this->getHitData(Word, false, Col, Row, ToT))
 					{
 						if(this->advancedConfig) this->transformChipsToModule(Col, Row, this->moduleIndex.at(chip));
-						eutelescope::EUTelGenericSparsePixel thisHit( Col, Row, ToT, lvl1-1);
-						sparseFrame->addSparsePixel( &thisHit );
+						//eutelescope::EUTelGenericSparsePixel thisHit( Col, Row, ToT, lvl1-1);
+						sparseFrame->emplace_back( Col, Row, ToT, lvl1-1 );
 					}
 					//Second Hit
 					if(this->getHitData(Word, true, Col, Row, ToT)) 
 					{
 						if(this->advancedConfig) this->transformChipsToModule(Col, Row, this->moduleIndex.at(chip));
-						eutelescope::EUTelGenericSparsePixel thisHit( Col, Row, ToT, lvl1-1);
-						sparseFrame->addSparsePixel( &thisHit );
+						//eutelescope::EUTelGenericSparsePixel thisHit( Col, Row, ToT, lvl1-1);
+						sparseFrame->emplace_back( Col, Row, ToT, lvl1-1 );
 					}
 				}
 			}

--- a/main/lib/plugins/USBpixConverterPlugin.cc
+++ b/main/lib/plugins/USBpixConverterPlugin.cc
@@ -274,8 +274,6 @@ namespace eudaq {
             setupDescription.push_back( new eutelescope::EUTelSetupDescription( currentDetector )) ;
           }
 
-          std::list<eutelescope::EUTelGenericSparsePixel*> tmphits;
-
           zsDataEncoder["sensorID"] = ev_raw.GetID(chip) + chip_id_offset + first_sensor_id;
           zsDataEncoder["sparsePixelType"] = eutelescope::kEUTelGenericSparsePixel;
 
@@ -301,18 +299,13 @@ namespace eudaq {
             if ((HEADER_MACRO(Word) == 1) && ((FLAG_MACRO(Word) & FLAG_WO_STATUS) == FLAG_WO_STATUS)) {
               lvl1++;
             } else if (getHitData(Word, Col, Row, ToT)) {
-              eutelescope::EUTelGenericSparsePixel *thisHit = new eutelescope::EUTelGenericSparsePixel( Col, Row, ToT, lvl1);
+              auto thisHit =  eutelescope::EUTelGenericSparsePixel( Col, Row, ToT, lvl1);
               sparseFrame->addSparsePixel( thisHit );
-              tmphits.push_back( thisHit );
             }
           }
 
           // write TrackerData object that contains info from one sensor to LCIO collection
           zsDataCollection->push_back( zsFrame.release() );
-
-          for( std::list<eutelescope::EUTelGenericSparsePixel*>::iterator it = tmphits.begin(); it != tmphits.end(); it++ ){
-            delete (*it);
-          }
         }
 
         // add this collection to lcio event


### PR DESCRIPTION
Updating various converter plugins to use the updated EUTelescope/LCIO interface

The (deprecated, see second PR) addSparsePixel() method now takes a const & instead of a *. Updated in all converter plugins which use this!