### PR TITLE
Fix compiler & Co warnings

### DIFF
--- a/main/lib/plugins/CaliceGenericConverterPlugin.cc
+++ b/main/lib/plugins/CaliceGenericConverterPlugin.cc
@@ -62,7 +62,7 @@ namespace eudaq {
       // Unpack data
       const RawDataEvent * rev = dynamic_cast<const RawDataEvent *> ( &ev );
 
-      int nblock =5; // the first 5 blocks contain information
+      unsigned int nblock =5; // the first 5 blocks contain information
       StandardPlane plane0(0, EVENT_TYPE, sensortype);
       plane0.SetSizeRaw( 36, 8);//36 channels, 4 chips
 

--- a/main/lib/plugins/CcpdlfConverterPlugin.cc
+++ b/main/lib/plugins/CcpdlfConverterPlugin.cc
@@ -58,7 +58,7 @@ namespace eudaq {
             if (rev->IsBORE() || rev->IsEORE()) return 0;
             if (rev->NumBlocks() <= 0)  return (unsigned) -1;
             const std::vector <unsigned char> & data=dynamic_cast<const std::vector<unsigned char> &> (rev->GetBlock(0));
-            if (data[3] & 0x80 !=0x80) return (unsigned) -1;
+            if ((data[3] & 0x80 )!=0x80) return (unsigned) -1;
             return  ((((unsigned int)data[3]) & 0x7F) << 24) |(((unsigned int)data[2]) << 16) |(((unsigned int)data[1]) << 8) | (unsigned int)data[0];
         }
         // If we are unable to extract the Trigger ID, signal with (unsigned)-1


### PR DESCRIPTION
- /home/travis/build/eudaq/eudaq/main/lib/plugins/CcpdlfConverterPlugin.cc:61:25:
& has lower precedence than !=; != will be evaluated first [-Wparentheses]
 if (data[3] & 0x80 !=0x80) return (unsigned) -1;
according to issue #182
Needs to be checked by maintainer of this system but the other possibility does not make sense.
- 