### PR TITLE
Disable rpi controller on mac as wiringPi does not build out of the box

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,16 +103,16 @@ matrix:
         env: OPTION=old
       - os: osx      
         compiler: gcc    
-        env: OPTION=modern    
+        env: OPTION=modern BUILD_rpi_controller=OFF
       - os: osx
         compiler: gcc      
-        env: OPTION=old BUILD_cmspixel=OFF
+        env: OPTION=old BUILD_cmspixel=OFF BUILD_rpi_controller=OFF
       - os: osx
         compiler: clang      
-        env: OPTION=modern
+        env: OPTION=modern BUILD_rpi_controller=OFF
       - os: osx      
         compiler: clang      
-        env: OPTION=old BUILD_cmspixel=OFF     
+        env: OPTION=old BUILD_cmspixel=OFF BUILD_rpi_controller=OFF    
 
 before_install:
   - source .travis/before_install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -112,7 +112,7 @@ matrix:
         env: OPTION=modern BUILD_rpi_controller=OFF
       - os: osx      
         compiler: clang      
-        env: OPTION=old BUILD_cmspixel=OFF BUILD_rpi_controller=OFF    
+        env: OPTION=old BUILD_cmspixel=OFF BUILD_rpi_controller=OFF     
 
 before_install:
   - source .travis/before_install.sh


### PR DESCRIPTION
and mac is not really the environment which runs on RPis.