### PR TITLE
Fix major bug in NI converter: losing 2nd M26 frame when converting to LCIO

### DIFF
--- a/main/lib/plugins/NIConverterPlugin.cc
+++ b/main/lib/plugins/NIConverterPlugin.cc
@@ -171,7 +171,8 @@ namespace eudaq {
         }
         StandardPlane plane(id, "NI", "MIMOSA26");
         plane.SetSizeZS(1152, 576, 0, 2, StandardPlane::FLAG_WITHPIVOT |
-                                             StandardPlane::FLAG_DIFFCOORDS);
+                                         StandardPlane::FLAG_DIFFCOORDS |
+			                 StandardPlane::FLAG_ACCUMULATE);
         plane.SetTLUEvent(tluid);
         plane.SetPivotPixel((9216 + pivot + PIVOTPIXELOFFSET) % 9216);
         DecodeFrame(plane, len0, it0 + 8, 0);


### PR DESCRIPTION
The missing flag FLAG_ACCUMULATE results in discarding the second M26 frame.
It is still read from the raw data and decoded, but the LCIO routine only
reads the first frame stored.

This affects all analyses using the NIConverterPlugin to convert M26 raw data to
StandardEvent or LCIO.

It has been discovered in CMS pixel data which showed correlation with the M26
planes in the OnlineMonitor, but not in LCIO. This data was apparently recorded
with a timing difference correlating the CMS hits with the second M26 frame.
The OnlineMon uses the StandardPlane format, reading all frames and thus shows
the correlation. The EUTelescope analysis uses the converted LCIO format
where the second frame and thus the correlation was lost.

This effect had first been seen already in 2015 CMS data taken at the DESY TB
and the bug has been discovered by Carlo Civinini (INFN Florence)