### PR TITLE
DO NOT MERGE YET: Backported getUniqueIdentifier from master branch

### DIFF
--- a/main/include/eudaq/DataConverterPlugin.hh
+++ b/main/include/eudaq/DataConverterPlugin.hh
@@ -169,6 +169,10 @@ namespace eudaq {
       return false;
     };
 
+    /** Returns each data converter instance first number of a ten sized block of reserved sensor IDs
+     */
+    virtual unsigned getUniqueIdentifier(const eudaq::Event  & ev);    
+    
     /** Returns the type of event this plugin can convert to lcio as a pair of
      * Event type id and subtype string.
      */
@@ -191,6 +195,8 @@ namespace eudaq {
      */
     DataConverterPlugin(std::string subtype);
     DataConverterPlugin(unsigned type, std::string subtype = "");
+    static unsigned m_count;
+    unsigned m_thisCount;
 
   private:
     /** The private copy constructor and assignment operator. They are not used

--- a/main/lib/plugins/DataConverterPlugin.cc
+++ b/main/lib/plugins/DataConverterPlugin.cc
@@ -39,12 +39,19 @@ namespace eudaq {
   }
 
   DataConverterPlugin::DataConverterPlugin(unsigned type, std::string subtype)
-      : m_eventtype(make_pair(type, subtype)) {
+      : m_eventtype(make_pair(type, subtype)), m_thisCount(m_count) {
     // std::cout << "DEBUG: Registering DataConverterPlugin: " <<
     // Event::id2str(m_eventtype.first) << ":" << m_eventtype.second <<
     // std::endl;
     PluginManager::GetInstance().RegisterPlugin(this);
+    m_count += 10;
   }
+  
+  unsigned DataConverterPlugin::getUniqueIdentifier(const eudaq::Event & ev) {
+   return m_thisCount;
+  }  
+  
+  unsigned DataConverterPlugin::m_count = 0;  
 
 #ifdef USE_EUTELESCOPE
   void ConvertPlaneToLCIOGenericPixel(StandardPlane &plane,


### PR DESCRIPTION
@tbisanz This is the solution in master for disentangling sensorID between different ConverterPlugins.