### PR TITLE
Fix to account for the new templated methods in eutelescope

### DIFF
--- a/main/include/eudaq/CMSPixelHelper.hh
+++ b/main/include/eudaq/CMSPixelHelper.hh
@@ -200,7 +200,7 @@ namespace eudaq {
           sparsePixel->setSignal((int32_t)plane.GetPixel(iPixel));
 
           // Add the pixel to the readout frame:
-          sparseFrame->addSparsePixel(sparsePixel.get());
+          sparseFrame->push_back(*sparsePixel.get());
         }
 
         // Now add the TrackerData to the collection


### PR DESCRIPTION
Correctet main/include/eudaq/CMSPixelHelper.hh which prevents me from compiling NREADER with CMSPIXEL