### PR TITLE
Removed obvious copy and paste mistake from eudet cmakelist leading t…

### DIFF
--- a/user/eudet/module/CMakeLists.txt
+++ b/user/eudet/module/CMakeLists.txt
@@ -15,7 +15,7 @@ if(NOT USER_BUILD_FMCTLU)
 endif()
 
 if(NOT EUDAQ_LCIO_LIBRARY)
-  list(REMOVE_ITEM MODULE_SRC src/TluRawEvent2LCEventCuseonverter.cc)
+  list(REMOVE_ITEM MODULE_SRC src/TluRawEvent2LCEventConverter.cc)
   list(REMOVE_ITEM MODULE_SRC src/NiRawEvent2LCEventConverter.cc)
   list(REMOVE_ITEM MODULE_SRC src/UsbpixrefRawEvent2LCEventConverter.cc)
 endif()


### PR DESCRIPTION
…o compilation problem on Windows due to missing lcio.