### PR TITLE
multiple threads among network and cmd/data processing 

### DIFF
--- a/gui/include/euProd.hh
+++ b/gui/include/euProd.hh
@@ -15,7 +15,6 @@ public:
   void DoTerminate() override {};
   void DoReset() override {};
 
-  void Exec() override final;
 private slots:
   void on_btnTrigger_clicked();
 };

--- a/gui/src/euLog.cc
+++ b/gui/src/euLog.cc
@@ -218,15 +218,14 @@ void LogCollectorGUI::CheckRegistered(){
 
 void LogCollectorGUI::Exec(){
   StartLogCollector(); //TODO: Start it OnServer
-  StartCommandReceiver();
-
+  Connect();
   show();
   if(QApplication::instance())
     QApplication::instance()->exec(); 
   else
     std::cerr<<"ERROR: LogCollectorGUI::EXEC\n";
 
-  while(IsActiveCommandReceiver() || IsActiveLogCollector()){
+  while(IsConnected() || IsActiveLogCollector()){
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
   }
 }

--- a/gui/src/euLog.cxx
+++ b/gui/src/euLog.cxx
@@ -1,43 +1,28 @@
 #include "eudaq/OptionParser.hh"
-#include "eudaq/Status.hh"
-#include "eudaq/Utils.hh"
-#include "eudaq/Logger.hh"
 #include "eudaq/LogCollector.hh"
+#include <iostream>
 #include <QApplication>
 
-namespace{
-  QCoreApplication* GetQApplication(){
-    QCoreApplication* qapp = QApplication::instance();
-    if(!qapp){
-      int argc = 1;
-      char *argv[] = {(char*)"euGUI"};
-      qapp = new QApplication(argc, argv );  
-    }
-    return qapp;
-  }
-  auto qapp = GetQApplication();
-}
-
-
 int main(int argc, char **argv) {
-  eudaq::OptionParser op("EUDAQ Log Collector", "1.0",
+  QCoreApplication *qapp = new QApplication(argc, argv );  
+  eudaq::OptionParser op("EUDAQ Log Collector", "2.0",
                          "A Qt version of the Log Collector");
   eudaq::Option<std::string> rctrl(op, "r", "runcontrol",
                                    "tcp://localhost:44000", "address",
                                    "The address of the RunControl application");
+  eudaq::Option<std::string> listen(op, "a", "listen-address", "", "address",
+				    "The address on which to listen for log connections");
   try {
     op.Parse(argv);
-    // EUDAQ_LOG_LEVEL(level.Value());
-    auto app=eudaq::Factory<eudaq::LogCollector>::
-      MakeShared<const std::string&, const std::string&>
-      (eudaq::cstr2hash("GuiLogCollector"), "log", rctrl.Value());
-    app->Exec();
   } catch (...) {
-    std::cout << "euLog exception handler" << std::endl;
     std::ostringstream err;
-    int result = op.HandleMainException(err);
-    std::cerr<<"Exception"<< err.str()<<"\n";
-    return result;
+    return op.HandleMainException(err);
   }
+
+  auto app=eudaq::Factory<eudaq::LogCollector>::
+    MakeShared<const std::string&, const std::string&>
+    (eudaq::cstr2hash("GuiLogCollector"), "log", rctrl.Value());
+  app->Exec();
+  
   return 0;
 }

--- a/gui/src/euLog.cxx
+++ b/gui/src/euLog.cxx
@@ -25,20 +25,12 @@ int main(int argc, char **argv) {
   eudaq::Option<std::string> rctrl(op, "r", "runcontrol",
                                    "tcp://localhost:44000", "address",
                                    "The address of the RunControl application");
-  eudaq::Option<std::string> listen(op, "a", "listen-address", "", "address",
-				    "The address on which to listen for Log connections");
   try {
     op.Parse(argv);
     // EUDAQ_LOG_LEVEL(level.Value());
     auto app=eudaq::Factory<eudaq::LogCollector>::
       MakeShared<const std::string&, const std::string&>
       (eudaq::cstr2hash("GuiLogCollector"), "log", rctrl.Value());
-    uint16_t port = static_cast<uint16_t>(eudaq::str2hash("log"+rctrl.Value()));
-    std::string addr_listen = "tcp://"+std::to_string(port);
-    if(!listen.Value().empty()){
-      addr_listen = listen.Value();
-    }
-    app->SetServerAddress(addr_listen);
     app->Exec();
   } catch (...) {
     std::cout << "euLog exception handler" << std::endl;

--- a/gui/src/euProd.cc
+++ b/gui/src/euProd.cc
@@ -6,17 +6,17 @@ ProducerGUI::ProducerGUI(const std::string & name, const std::string &runcontrol
   setupUi(this);
 }
 
-void ProducerGUI::Exec(){
-  show();
-  if(QApplication::instance()){
-    std::thread qthread(&Producer::Exec, this); //TODO: is QCore?
-    qthread.detach();
-    QApplication::instance()->exec();
-    // Producer::Exec();
-  }
-  else
-    std::cerr<<"ERROR: ProducerGUI::EXEC\n";
-}
+// void ProducerGUI::Exec(){
+//   show();
+//   if(QApplication::instance()){
+//     std::thread qthread(&Producer::Exec, this); //TODO: is QCore?
+//     qthread.detach();
+//     QApplication::instance()->exec();
+//     // Producer::Exec();
+//   }
+//   else
+//     std::cerr<<"ERROR: ProducerGUI::EXEC\n";
+// }
 
 void ProducerGUI::on_btnTrigger_clicked() {
     QMessageBox::information(this, "EUDAQ Dummy Producer",

--- a/main/exe/src/euCliDataCollector.cxx
+++ b/main/exe/src/euCliDataCollector.cxx
@@ -12,36 +12,36 @@ int main(int /*argc*/, const char **argv) {
 				  "The port on which the data collector is going to listen on");
   eudaq::Option<std::string> rctrl(op, "r", "runcontrol", "tcp://localhost:44000", "address",
   				   "The address of the RunControl to connect to");
-  op.Parse(argv);
+
+  try{
+    op.Parse(argv);
+  }
+  catch(...){
+    std::ostringstream err;
+    return op.HandleMainException(err);
+  }
   std::string app_name = name.Value();
   if(app_name.find("DataCollector") != std::string::npos){
-    auto app=eudaq::Factory<eudaq::DataCollector>::MakeShared<const std::string&,const std::string&>
-      (eudaq::str2hash(name.Value()), tname.Value(), rctrl.Value());
-    if(!app){
-      std::cout<<"unknown DataCollector"<<std::endl;
-      return -1;
-    }
-
-    uint16_t port = static_cast<uint16_t>(eudaq::str2hash(name.Value()+tname.Value()+rctrl.Value()));
-    std::string addr_listen = "tcp://"+std::to_string(port);
-    if(!listen.Value().empty()){
-      addr_listen = listen.Value();
-    }
-    app->SetServerAddress(addr_listen);
-    
-    try{
-      app->Connect();
-    }
-    catch (...){
-      std::cout<<"Can not connect to RunContrl at "<<rctrl.Value()<<std::endl;
-    }
-    while(app->IsConnected()){
-      std::this_thread::sleep_for(std::chrono::seconds(1));
-    }
-  }
-  else{
     std::cout<<"unknown application"<<std::endl;
     return -1;
+  }
+  auto app=eudaq::DataCollector::Make(name.Value(), tname.Value(), rctrl.Value());
+  if(!app){
+    std::cout<<"unknown DataCollector: "<<name.Value()<<std::endl;
+    return -1;
+  }
+  if(!listen.Value().empty()){
+    app->SetServerAddress(listen.Value());
+  }
+  try{
+    app->Connect();
+  }
+  catch (...){
+    std::cout<<"Can not connect to RunContrl at "<<rctrl.Value()<<std::endl;
+    return -1;
+  }
+  while(app->IsConnected()){
+    std::this_thread::sleep_for(std::chrono::seconds(1));
   }
   return 0;
 }

--- a/main/exe/src/euCliDataCollector.cxx
+++ b/main/exe/src/euCliDataCollector.cxx
@@ -28,7 +28,7 @@ int main(int /*argc*/, const char **argv) {
       addr_listen = listen.Value();
     }
     app->SetServerAddress(addr_listen);
-    app->Exec();
+    // app->Exec();
   }
   else{
     std::cout<<"unknown application"<<std::endl;

--- a/main/exe/src/euCliDataCollector.cxx
+++ b/main/exe/src/euCliDataCollector.cxx
@@ -28,7 +28,16 @@ int main(int /*argc*/, const char **argv) {
       addr_listen = listen.Value();
     }
     app->SetServerAddress(addr_listen);
-    // app->Exec();
+    
+    try{
+      app->Connect();
+    }
+    catch (...){
+      std::cout<<"Can not connect to RunContrl at "<<rctrl.Value()<<std::endl;
+    }
+    while(app->IsConnected()){
+      std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
   }
   else{
     std::cout<<"unknown application"<<std::endl;

--- a/main/exe/src/euCliDataCollector.cxx
+++ b/main/exe/src/euCliDataCollector.cxx
@@ -21,7 +21,7 @@ int main(int /*argc*/, const char **argv) {
     return op.HandleMainException(err);
   }
   std::string app_name = name.Value();
-  if(app_name.find("DataCollector") != std::string::npos){
+  if(app_name.find("DataCollector") == std::string::npos){
     std::cout<<"unknown application"<<std::endl;
     return -1;
   }

--- a/main/exe/src/euCliLog.cxx
+++ b/main/exe/src/euCliLog.cxx
@@ -13,27 +13,23 @@ int main(int /*argc*/, const char **argv) {
 				    "The address on which to listen for log connections");
   try{
     op.Parse(argv);
-    auto app=eudaq::Factory<eudaq::LogCollector>::
-      MakeShared<const std::string&,const std::string&>
-      (eudaq::str2hash(name.Value()), "Log" ,rctrl.Value());
-    if(!app){
-      std::cout<<"unknown LogCollector"<<std::endl;
-      return -1;
-    }
-    uint16_t port = static_cast<uint16_t>(eudaq::str2hash(name.Value()+"Log"+rctrl.Value()));
-    std::string addr_listen = "tcp://"+std::to_string(port);
-    if(!listen.Value().empty()){
-      addr_listen = listen.Value();
-    }
-    app->SetServerAddress(addr_listen);
-    app->Exec();
   }
   catch(...){
-    std::cout << "euLog exception handler" << std::endl;
     std::ostringstream err;
-    int result = op.HandleMainException(err);
-    std::cerr<<"Exception"<< err.str()<<"\n";
-    return result;
+    return op.HandleMainException(err);
   }
+    
+  auto app=eudaq::Factory<eudaq::LogCollector>::
+    MakeShared<const std::string&,const std::string&>
+    (eudaq::str2hash(name.Value()), "log" ,rctrl.Value());
+  if(!app){
+    std::cout<<"unknown LogCollector"<<std::endl;
+    return -1;
+  }
+
+  if(!listen.Value().empty()){
+    app->SetServerAddress(listen.Value());
+  }
+  app->Exec();
   return 0;
 }

--- a/main/exe/src/euCliMonitor.cxx
+++ b/main/exe/src/euCliMonitor.cxx
@@ -12,27 +12,37 @@ int main(int /*argc*/, const char **argv) {
 				  "The port on which the data monitor is going to listen on");
   eudaq::Option<std::string> rctrl(op, "r", "runcontrol", "tcp://localhost:44000", "address",
   				   "The address of the RunControl to connect to");
-  op.Parse(argv);
+
+
+  try{
+    op.Parse(argv);
+  }
+  catch(...){
+    std::ostringstream err;
+    return op.HandleMainException(err);
+  }
   std::string app_name = name.Value();
   if(app_name.find("Monitor") != std::string::npos){
-    auto app=eudaq::Factory<eudaq::Monitor>::MakeShared<const std::string&,const std::string&>
-      (eudaq::str2hash(name.Value()), tname.Value(), rctrl.Value());
-    if(!app){
-      std::cout<<"unknow Monitor"<<std::endl;
-      return -1;
-    }
-
-    uint16_t port = static_cast<uint16_t>(eudaq::str2hash(name.Value()+tname.Value()+rctrl.Value()));
-    std::string addr_listen = "tcp://"+std::to_string(port);
-    if(!listen.Value().empty()){
-      addr_listen = listen.Value();
-    }
-    app->SetServerAddress(addr_listen);
-    // app->Exec();
-  }
-  else{
-    std::cout<<"unknow application"<<std::endl;
+    std::cout<<"unknown application"<<std::endl;
     return -1;
+  }
+  auto app=eudaq::Monitor::Make(name.Value(), tname.Value(), rctrl.Value());
+  if(!app){
+    std::cout<<"unknown Monitor: "<<name.Value()<<std::endl;
+    return -1;
+  }
+  if(!listen.Value().empty()){
+    app->SetServerAddress(listen.Value());
+  }
+  try{
+    app->Connect();
+  }
+  catch (...){
+    std::cout<<"Can not connect to RunContrl at "<<rctrl.Value()<<std::endl;
+    return -1;
+  }
+  while(app->IsConnected()){
+    std::this_thread::sleep_for(std::chrono::seconds(1));
   }
   return 0;
 }

--- a/main/exe/src/euCliMonitor.cxx
+++ b/main/exe/src/euCliMonitor.cxx
@@ -28,7 +28,7 @@ int main(int /*argc*/, const char **argv) {
       addr_listen = listen.Value();
     }
     app->SetServerAddress(addr_listen);
-    app->Exec();
+    // app->Exec();
   }
   else{
     std::cout<<"unknow application"<<std::endl;

--- a/main/exe/src/euCliMonitor.cxx
+++ b/main/exe/src/euCliMonitor.cxx
@@ -22,7 +22,7 @@ int main(int /*argc*/, const char **argv) {
     return op.HandleMainException(err);
   }
   std::string app_name = name.Value();
-  if(app_name.find("Monitor") != std::string::npos){
+  if(app_name.find("Monitor") == std::string::npos){
     std::cout<<"unknown application"<<std::endl;
     return -1;
   }

--- a/main/exe/src/euCliProducer.cxx
+++ b/main/exe/src/euCliProducer.cxx
@@ -18,7 +18,7 @@ int main(int /*argc*/, const char **argv) {
     return op.HandleMainException(err);
   }
   std::string app_name = name.Value();
-  if(app_name.find("Producer") != std::string::npos){
+  if(app_name.find("Producer") == std::string::npos){
     std::cout<<"unknown application"<<std::endl;
     return -1;
   }

--- a/main/exe/src/euCliProducer.cxx
+++ b/main/exe/src/euCliProducer.cxx
@@ -19,7 +19,9 @@ int main(int /*argc*/, const char **argv) {
       std::cout<<"unknown Producer"<<std::endl;
       return -1;
     }
-    app->Exec();
+    app->Connect();
+    std::chrono::seconds t(500);
+    std::this_thread::sleep_for(t);
   }
   else{
     std::cout<<"unknown application"<<std::endl;

--- a/main/exe/src/euCliProducer.cxx
+++ b/main/exe/src/euCliProducer.cxx
@@ -10,29 +10,32 @@ int main(int /*argc*/, const char **argv) {
 				  "Runtime name of the eudaq application");
   eudaq::Option<std::string> rctrl(op, "r", "runcontrol", "tcp://localhost:44000", "address",
   				   "The address of the run control to connect to");
-  op.Parse(argv);
+  try{
+    op.Parse(argv);
+  }
+  catch(...){
+    std::ostringstream err;
+    return op.HandleMainException(err);
+  }
   std::string app_name = name.Value();
   if(app_name.find("Producer") != std::string::npos){
-    auto app=eudaq::Factory<eudaq::Producer>::MakeShared<const std::string&,const std::string&>
-      (eudaq::str2hash(name.Value()), tname.Value(), rctrl.Value());
-    if(!app){
-      std::cout<<"unknown Producer"<<std::endl;
-      return -1;
-    }
-    try{
-      app->Connect();
-    }
-    catch (...){
-      std::cout<<"Can not connect to RunContrl at "<<rctrl.Value()<<std::endl;
-    }
-    while(app->IsConnected()){
-      std::this_thread::sleep_for(std::chrono::seconds(1));
-    }
-    
-  }
-  else{
     std::cout<<"unknown application"<<std::endl;
     return -1;
+  }
+  auto app=eudaq::Producer::Make(name.Value(), tname.Value(), rctrl.Value());
+  if(!app){
+    std::cout<<"unknown Producer: "<<name.Value()<<std::endl;
+    return -1;
+  }  
+  try{
+    app->Connect();
+  }
+  catch (...){
+    std::cout<<"Can not connect to RunContrl at "<<rctrl.Value()<<std::endl;
+    return -1;
+  }
+  while(app->IsConnected()){
+    std::this_thread::sleep_for(std::chrono::seconds(1));
   }
   return 0;
 }

--- a/main/exe/src/euCliProducer.cxx
+++ b/main/exe/src/euCliProducer.cxx
@@ -19,9 +19,16 @@ int main(int /*argc*/, const char **argv) {
       std::cout<<"unknown Producer"<<std::endl;
       return -1;
     }
-    app->Connect();
-    std::chrono::seconds t(500);
-    std::this_thread::sleep_for(t);
+    try{
+      app->Connect();
+    }
+    catch (...){
+      std::cout<<"Can not connect to RunContrl at "<<rctrl.Value()<<std::endl;
+    }
+    while(app->IsConnected()){
+      std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+    
   }
   else{
     std::cout<<"unknown application"<<std::endl;

--- a/main/lib/core/include/eudaq/CommandReceiver.hh
+++ b/main/lib/core/include/eudaq/CommandReceiver.hh
@@ -25,36 +25,33 @@ namespace eudaq {
     CommandReceiver(const std::string & type, const std::string & name,
 		    const std::string & runcontrol);
     virtual ~CommandReceiver();
-
     virtual void OnInitialise(); 
     virtual void OnConfigure();
     virtual void OnStartRun();
     virtual void OnStopRun();
     virtual void OnTerminate();
     virtual void OnReset();
-    virtual void OnStatus(){}
+    virtual void OnStatus();
     virtual void OnLog(const std::string & /*param*/);
-    virtual void OnUnrecognised(const std::string & /*cmd*/, const std::string & /*param*/) {}
+    virtual void OnUnrecognised(const std::string & /*cmd*/, const std::string & /*param*/);
     virtual bool RunLoop();
-    virtual void Exec();
     
     void SetStatus(Status::State state, const std::string & info);
     bool IsStatus(Status::State state);
     void SetStatusTag(const std::string &key, const std::string &val);
     
-    std::string GetFullName() const {return m_type+"."+m_name;};
-    std::string GetName() const {return m_name;};
-    uint32_t GetRunNumber() const {return m_run_number;};
-    std::string GetCommandRecieverAddress() const {return m_addr_client;};
+    std::string GetFullName() const;
+    std::string GetName() const;
+    uint32_t GetRunNumber() const;
+    std::string GetCommandRecieverAddress() const;
     
-    ConfigurationSPC GetConfiguration() const {return m_conf;};
-    ConfigurationSPC GetInitConfiguration() const {return m_conf_init;};
+    ConfigurationSPC GetConfiguration() const;
+    ConfigurationSPC GetInitConfiguration() const;
 
-    std::string Connect(const std::string &addr);
-    std::string Connect(){Connect(m_addr_runctrl);}
-    bool IsConnected(){return m_is_connected;}
-    void StartCommandReceiver(){Connect();}
-    bool IsActiveCommandReceiver(){return m_is_connected;}
+    std::string Connect();
+    bool IsConnected();
+    void StartCommandReceiver();
+    bool IsActiveCommandReceiver();
   private:
     void CommandHandler(TransportEvent &);
     bool Deamon();

--- a/main/lib/core/include/eudaq/CommandReceiver.hh
+++ b/main/lib/core/include/eudaq/CommandReceiver.hh
@@ -23,7 +23,7 @@ namespace eudaq {
   class DLLEXPORT CommandReceiver {
   public:
     CommandReceiver(const std::string & type, const std::string & name,
-		    const std::string & runcontrol);
+		    const std::string & runctrl);
     virtual ~CommandReceiver();
     virtual void OnInitialise(); 
     virtual void OnConfigure();
@@ -32,23 +32,22 @@ namespace eudaq {
     virtual void OnTerminate();
     virtual void OnReset();
     virtual void OnStatus();
-    virtual void OnLog(const std::string & /*param*/);
-    virtual void OnUnrecognised(const std::string & /*cmd*/, const std::string & /*param*/);
-    virtual bool RunLoop();
+    virtual void OnLog(const std::string &log);
+    virtual void OnUnrecognised(const std::string &cmd, const std::string &argv);
+    virtual void RunLoop();
+    std::string Connect();
     
-    void SetStatus(Status::State state, const std::string & info);
-    bool IsStatus(Status::State state);
+    void SetStatus(Status::State, const std::string&);
+    void SetStatusMsg(const std::string&);
     void SetStatusTag(const std::string &key, const std::string &val);
-    
+
     std::string GetFullName() const;
     std::string GetName() const;
     uint32_t GetRunNumber() const;
-    
     ConfigurationSPC GetConfiguration() const;
     ConfigurationSPC GetInitConfiguration() const;
-
-    std::string Connect();
     bool IsConnected() const;
+    bool IsStatus(Status::State);
   private:
     void CommandHandler(TransportEvent &);
     bool Deamon();
@@ -71,10 +70,8 @@ namespace eudaq {
     std::mutex m_mx_deamon;
     std::queue<std::pair<std::string, std::string>> m_qu_cmd;
     std::condition_variable m_cv_not_empty;
-
     Status m_status;
     std::mutex m_mtx_status;
-
     std::shared_ptr<Configuration> m_conf;
     std::shared_ptr<Configuration> m_conf_init;
     std::string m_type;

--- a/main/lib/core/include/eudaq/CommandReceiver.hh
+++ b/main/lib/core/include/eudaq/CommandReceiver.hh
@@ -37,6 +37,7 @@ namespace eudaq {
     virtual void RunLoop();
     std::string Connect();
     
+    void SendStatus();
     void SetStatus(Status::State, const std::string&);
     void SetStatusMsg(const std::string&);
     void SetStatusTag(const std::string &key, const std::string &val);

--- a/main/lib/core/include/eudaq/CommandReceiver.hh
+++ b/main/lib/core/include/eudaq/CommandReceiver.hh
@@ -43,15 +43,12 @@ namespace eudaq {
     std::string GetFullName() const;
     std::string GetName() const;
     uint32_t GetRunNumber() const;
-    std::string GetCommandRecieverAddress() const;
     
     ConfigurationSPC GetConfiguration() const;
     ConfigurationSPC GetInitConfiguration() const;
 
     std::string Connect();
-    bool IsConnected();
-    void StartCommandReceiver();
-    bool IsActiveCommandReceiver();
+    bool IsConnected() const;
   private:
     void CommandHandler(TransportEvent &);
     bool Deamon();
@@ -83,7 +80,6 @@ namespace eudaq {
     std::string m_type;
     std::string m_name;
     uint32_t m_run_number;
-    
   };
 }
 

--- a/main/lib/core/include/eudaq/DataCollector.hh
+++ b/main/lib/core/include/eudaq/DataCollector.hh
@@ -33,8 +33,6 @@ namespace eudaq {
   public:
     DataCollector(const std::string &name, const std::string &runcontrol);
     ~DataCollector() override;
-
-    //running in commandreceiver thread
     virtual void DoInitialise();
     virtual void DoConfigure();
     virtual void DoStartRun();
@@ -42,19 +40,14 @@ namespace eudaq {
     virtual void DoReset();
     virtual void DoTerminate();
     virtual void DoStatus();
-
-    //running in datareceiver thread
     virtual void DoConnect(ConnectionSPC id);
     virtual void DoDisconnect(ConnectionSPC id);
     virtual void DoReceive(ConnectionSPC id, EventSP ev);
-    
     void WriteEvent(EventSP ev);
     void SetServerAddress(const std::string &addr);
-
     static DataCollectorSP Make(const std::string &code_name,
 				const std::string &run_name,
 				const std::string &runcontrol);
-
   private:
     void OnInitialise() override final;
     void OnConfigure() override final;
@@ -63,13 +56,10 @@ namespace eudaq {
     void OnReset() override final;
     void OnTerminate() override final;
     void OnStatus() override final;
-
     void OnConnect(ConnectionSPC id) override final;
     void OnDisconnect(ConnectionSPC id) override final;
     void OnReceive(ConnectionSPC id, EventSP ev) override final;
-
   private:
-    bool m_exit;
     std::string m_data_addr;
     FileWriterUP m_writer;
     std::unique_ptr<DataReceiver> m_receiver;
@@ -78,7 +68,7 @@ namespace eudaq {
     std::string m_fwtype;
     uint32_t m_dct_n;
     uint32_t m_evt_c;
-    std::unique_ptr<const Configuration> m_conf;
+    ConfigurationSPC m_conf;
   };
   //----------DOC-MARK-----END*DEC-----DOC-MARK----------
 }

--- a/main/lib/core/include/eudaq/DataCollector.hh
+++ b/main/lib/core/include/eudaq/DataCollector.hh
@@ -27,6 +27,8 @@ namespace eudaq {
   Factory<DataCollector>::Instance<const std::string&, const std::string&>();
 #endif
 
+  using DataCollectorSP = Factory<DataCollector>::SP_BASE;
+  
   //----------DOC-MARK-----BEG*DEC-----DOC-MARK----------
   class DLLEXPORT DataCollector : public CommandReceiver {
   public:
@@ -58,6 +60,11 @@ namespace eudaq {
     void StartDataCollector();
     void CloseDataCollector();
     bool IsActiveDataCollector(){return m_thd_server.joinable();}
+
+    static DataCollectorSP Make(const std::string &code_name,
+				const std::string &run_name,
+				const std::string &runcontrol);
+
   private:
     void DataHandler(TransportEvent &ev);
     void DataThread();

--- a/main/lib/core/include/eudaq/DataCollector.hh
+++ b/main/lib/core/include/eudaq/DataCollector.hh
@@ -49,6 +49,7 @@ namespace eudaq {
     virtual void DoStopRun(){};
     virtual void DoReset(){};
     virtual void DoTerminate(){};
+    virtual void DoStatus(){};
 
     //running in dataserver thread
     virtual void DoConnect(ConnectionSPC id) {}

--- a/main/lib/core/include/eudaq/DataCollector.hh
+++ b/main/lib/core/include/eudaq/DataCollector.hh
@@ -33,7 +33,6 @@ namespace eudaq {
   public:
     DataCollector(const std::string &name, const std::string &runcontrol);
     ~DataCollector() override;
-    void Exec() override;
 
     //running in commandreceiver thread
     virtual void DoInitialise(){};

--- a/main/lib/core/include/eudaq/DataCollector.hh
+++ b/main/lib/core/include/eudaq/DataCollector.hh
@@ -32,6 +32,7 @@ namespace eudaq {
   class DLLEXPORT DataCollector : public CommandReceiver, public DataReceiver {
   public:
     DataCollector(const std::string &name, const std::string &runcontrol);
+    ~DataCollector() override;
     void Exec() override;
 
     //running in commandreceiver thread

--- a/main/lib/core/include/eudaq/DataCollector.hh
+++ b/main/lib/core/include/eudaq/DataCollector.hh
@@ -35,21 +35,21 @@ namespace eudaq {
     ~DataCollector() override;
 
     //running in commandreceiver thread
-    virtual void DoInitialise(){};
-    virtual void DoConfigure(){};
-    virtual void DoStartRun(){};
-    virtual void DoStopRun(){};
-    virtual void DoReset(){};
-    virtual void DoTerminate(){};
-    virtual void DoStatus(){};
+    virtual void DoInitialise();
+    virtual void DoConfigure();
+    virtual void DoStartRun();
+    virtual void DoStopRun();
+    virtual void DoReset();
+    virtual void DoTerminate();
+    virtual void DoStatus();
 
     //running in datareceiver thread
-    virtual void DoConnect(ConnectionSPC id) {}
-    virtual void DoDisconnect(ConnectionSPC id) {}
-    virtual void DoReceive(ConnectionSPC id, EventSP ev){};
+    virtual void DoConnect(ConnectionSPC id);
+    virtual void DoDisconnect(ConnectionSPC id);
+    virtual void DoReceive(ConnectionSPC id, EventSP ev);
     
     void WriteEvent(EventSP ev);
-    void SetServerAddress(const std::string &addr){m_data_addr = addr;};
+    void SetServerAddress(const std::string &addr);
 
     static DataCollectorSP Make(const std::string &code_name,
 				const std::string &run_name,

--- a/main/lib/core/include/eudaq/DataReceiver.hh
+++ b/main/lib/core/include/eudaq/DataReceiver.hh
@@ -36,6 +36,7 @@ namespace eudaq {
     virtual void OnDisconnect(ConnectionSPC id);
     virtual void OnReceive(ConnectionSPC id, EventSP ev);
     std::string Listen(const std::string &addr);
+    std::string StopListen(){m_is_listening = false;}; //TODO: remove this method later
   private:
     void DataHandler(TransportEvent &ev);
     bool Deamon();
@@ -44,6 +45,7 @@ namespace eudaq {
     
   private:
     std::unique_ptr<TransportServer> m_dataserver;
+    std::string m_last_addr;
     std::vector<ConnectionSP> m_vt_con;
     bool m_is_destructing;
     bool m_is_listening;

--- a/main/lib/core/include/eudaq/DataReceiver.hh
+++ b/main/lib/core/include/eudaq/DataReceiver.hh
@@ -1,0 +1,61 @@
+#ifndef EUDAQ_INCLUDED_DataReceiver
+#define EUDAQ_INCLUDED_DataReceiver
+
+#include "eudaq/TransportServer.hh"
+#include "eudaq/CommandReceiver.hh"
+#include "eudaq/Event.hh"
+#include "eudaq/FileWriter.hh"
+#include "eudaq/DataSender.hh"
+#include "eudaq/Configuration.hh"
+#include "eudaq/Utils.hh"
+#include "eudaq/Platform.hh"
+#include "eudaq/Factory.hh"
+
+#include <string>
+#include <vector>
+#include <list>
+#include <memory>
+#include <atomic>
+#include <future>
+#include <thread>
+#include <queue>
+#include <mutex>
+#include <condition_variable>
+#include <type_traits>
+
+namespace eudaq {
+  class DataReceiver;
+  
+  using DataReceiverSP = Factory<DataReceiver>::SP_BASE;
+
+  class DLLEXPORT DataReceiver{
+  public:
+    DataReceiver();
+    virtual ~DataReceiver();
+    virtual void OnConnect(ConnectionSPC id);
+    virtual void OnDisconnect(ConnectionSPC id);
+    virtual void OnReceive(ConnectionSPC id, EventSP ev);
+    void Listen(const std::string &addr);
+  private:
+    void DataHandler(TransportEvent &ev);
+    bool Deamon();
+    bool AsyncReceiving();
+    bool AsyncForwarding();
+    
+  private:
+    std::unique_ptr<TransportServer> m_dataserver;
+    std::vector<ConnectionSP> m_vt_con;
+    bool m_is_destructing;
+    bool m_is_listening;
+    std::future<bool> m_fut_async_rcv;
+    std::future<bool> m_fut_async_fwd;
+    std::future<bool> m_fut_deamon;
+    std::mutex m_mx_qu_ev;
+    std::mutex m_mx_deamon;
+    std::queue<std::pair<EventSP, ConnectionSPC>> m_qu_ev;
+    std::condition_variable m_cv_not_empty;
+  };
+  //----------DOC-MARK-----END*DEC-----DOC-MARK----------
+}
+
+#endif // EUDAQ_INCLUDED_DataReceiver

--- a/main/lib/core/include/eudaq/DataReceiver.hh
+++ b/main/lib/core/include/eudaq/DataReceiver.hh
@@ -35,7 +35,7 @@ namespace eudaq {
     virtual void OnConnect(ConnectionSPC id);
     virtual void OnDisconnect(ConnectionSPC id);
     virtual void OnReceive(ConnectionSPC id, EventSP ev);
-    void Listen(const std::string &addr);
+    std::string Listen(const std::string &addr);
   private:
     void DataHandler(TransportEvent &ev);
     bool Deamon();

--- a/main/lib/core/include/eudaq/DataReceiver.hh
+++ b/main/lib/core/include/eudaq/DataReceiver.hh
@@ -49,6 +49,7 @@ namespace eudaq {
     std::vector<ConnectionSP> m_vt_con;
     bool m_is_destructing;
     bool m_is_listening;
+    bool m_is_async_rcv_return;
     std::future<bool> m_fut_async_rcv;
     std::future<bool> m_fut_async_fwd;
     std::future<bool> m_fut_deamon;

--- a/main/lib/core/include/eudaq/DataReceiver.hh
+++ b/main/lib/core/include/eudaq/DataReceiver.hh
@@ -36,7 +36,7 @@ namespace eudaq {
     virtual void OnDisconnect(ConnectionSPC id);
     virtual void OnReceive(ConnectionSPC id, EventSP ev);
     std::string Listen(const std::string &addr);
-    std::string StopListen(){m_is_listening = false;}; //TODO: remove this method later
+    void StopListen();//TODO: remove this method later
   private:
     void DataHandler(TransportEvent &ev);
     bool Deamon();

--- a/main/lib/core/include/eudaq/DataSender.hh
+++ b/main/lib/core/include/eudaq/DataSender.hh
@@ -5,20 +5,32 @@
 #include "eudaq/Platform.hh"
 #include "eudaq/Event.hh"
 #include <string>
+#include <future>
+#include <thread>
+#include <queue>
+#include <mutex>
+#include <condition_variable>
 
 namespace eudaq {
 
 class TransportClient;
 
   class DLLEXPORT DataSender {
-    public:
+  public:
       DataSender(const std::string & type, const std::string & name);
+      ~DataSender();
       void Connect(const std::string & server);
       void SendEvent(EventSPC ev);
-    private:
+  private:
+      bool AsyncSending();
       std::string m_type, m_name;
       std::unique_ptr<TransportClient> m_dataclient;
       uint64_t m_packetCounter;
+      std::future<bool> m_fut_async;
+      bool m_is_connected;
+      std::mutex m_mx_qu_ev; 
+      std::queue<EventSPC> m_qu_ev;
+      std::condition_variable m_cv_not_empty;
   };
 
 }

--- a/main/lib/core/include/eudaq/DataSender.hh
+++ b/main/lib/core/include/eudaq/DataSender.hh
@@ -3,18 +3,18 @@
 
 
 #include "eudaq/Platform.hh"
+#include "eudaq/Event.hh"
 #include <string>
 
 namespace eudaq {
 
 class TransportClient;
-class Event;
 
   class DLLEXPORT DataSender {
     public:
       DataSender(const std::string & type, const std::string & name);
       void Connect(const std::string & server);
-      void SendEvent(const Event &);
+      void SendEvent(EventSPC ev);
     private:
       std::string m_type, m_name;
       std::unique_ptr<TransportClient> m_dataclient;

--- a/main/lib/core/include/eudaq/LogCollector.hh
+++ b/main/lib/core/include/eudaq/LogCollector.hh
@@ -31,7 +31,7 @@ namespace eudaq {
     void OnInitialise() override final;
     void OnTerminate() override final;
     void OnLog(const std::string &param) override final{};
-    void Exec() override;
+    virtual void Exec();
 
     virtual void DoInitialise(){};
     virtual void DoTerminate(){};

--- a/main/lib/core/include/eudaq/LogCollector.hh
+++ b/main/lib/core/include/eudaq/LogCollector.hh
@@ -22,7 +22,7 @@ namespace eudaq {
 #endif
   
   class LogMessage;
-
+  using LogCollectorSP = Factory<LogCollector>::SP_BASE;
   class DLLEXPORT LogCollector : public CommandReceiver {
   public:
     LogCollector(const std::string &name, const std::string &runcontrol);
@@ -44,6 +44,10 @@ namespace eudaq {
     void StartLogCollector();
     void CloseLogCollector();
     bool IsActiveLogCollector(){return m_thd_server.joinable();}
+
+    static LogCollectorSP Make(const std::string &code_name,
+			       const std::string &run_name,
+			       const std::string &runcontrol);
   private:
     void LogThread();
     void LogHandler(TransportEvent &ev);

--- a/main/lib/core/include/eudaq/Monitor.hh
+++ b/main/lib/core/include/eudaq/Monitor.hh
@@ -31,14 +31,6 @@ namespace eudaq {
   class DLLEXPORT Monitor : public CommandReceiver, public DataReceiver{
   public:
     Monitor(const std::string &name, const std::string &runcontrol);
-    void OnInitialise() override final;
-    void OnConfigure() override final;
-    void OnStartRun() override final;
-    void OnStopRun() override final;
-    void OnReset() override final;
-    void OnTerminate() override final;
-    void OnStatus() override final;
-    void Exec() override;
 
     //running in commandreceiver thread
     virtual void DoInitialise(){};
@@ -53,22 +45,25 @@ namespace eudaq {
     virtual void DoReceive(EventSP ev){};
     
     void SetServerAddress(const std::string &addr){m_data_addr = addr;};
-    void StartMonitor();
-    void CloseMonitor();
-    bool IsActiveMonitor(){return m_thd_server.joinable();}
 
     static MonitorSP Make(const std::string &code_name,
 			  const std::string &run_name,
 			  const std::string &runcontrol);
 
   private:
-    void DataHandler(TransportEvent &ev);
-    void DataThread();
+    void OnInitialise() override final;
+    void OnConfigure() override final;
+    void OnStartRun() override final;
+    void OnStopRun() override final;
+    void OnReset() override final;
+    void OnTerminate() override final;
+    void OnStatus() override final;
 
+    // void OnConnect(ConnectionSPC id) override final;
+    // void OnDisconnect(ConnectionSPC id) override final;
+    void OnReceive(ConnectionSPC id, EventSP ev) override final;
+    
   private:
-    std::thread m_thd_server;
-    bool m_exit;
-    std::unique_ptr<TransportServer> m_dataserver;
     std::string m_data_addr;
   };
   //----------DOC-MARK-----END*DEC-----DOC-MARK----------

--- a/main/lib/core/include/eudaq/Monitor.hh
+++ b/main/lib/core/include/eudaq/Monitor.hh
@@ -25,6 +25,8 @@ namespace eudaq {
   Factory<Monitor>::Instance<const std::string&, const std::string&>();
 #endif
 
+  using MonitorSP = Factory<Monitor>::SP_BASE;
+  
   //----------DOC-MARK-----BEG*DEC-----DOC-MARK----------
   class DLLEXPORT Monitor : public CommandReceiver {
   public:
@@ -53,6 +55,11 @@ namespace eudaq {
     void StartMonitor();
     void CloseMonitor();
     bool IsActiveMonitor(){return m_thd_server.joinable();}
+
+    static MonitorSP Make(const std::string &code_name,
+			  const std::string &run_name,
+			  const std::string &runcontrol);
+
   private:
     void DataHandler(TransportEvent &ev);
     void DataThread();

--- a/main/lib/core/include/eudaq/Monitor.hh
+++ b/main/lib/core/include/eudaq/Monitor.hh
@@ -31,25 +31,18 @@ namespace eudaq {
   class DLLEXPORT Monitor : public CommandReceiver, public DataReceiver{
   public:
     Monitor(const std::string &name, const std::string &runcontrol);
-
-    //running in commandreceiver thread
-    virtual void DoInitialise(){};
-    virtual void DoConfigure(){};
-    virtual void DoStartRun(){};
-    virtual void DoStopRun(){};
-    virtual void DoReset(){};
-    virtual void DoTerminate(){};
-    virtual void DoStatus(){};
-
-    //running in dataserver thread
-    virtual void DoReceive(EventSP ev){};
-    
-    void SetServerAddress(const std::string &addr){m_data_addr = addr;};
-
+    virtual void DoInitialise();
+    virtual void DoConfigure();
+    virtual void DoStartRun();
+    virtual void DoStopRun();
+    virtual void DoReset();
+    virtual void DoTerminate();
+    virtual void DoStatus();
+    virtual void DoReceive(EventSP ev);
+    void SetServerAddress(const std::string &addr);
     static MonitorSP Make(const std::string &code_name,
 			  const std::string &run_name,
 			  const std::string &runcontrol);
-
   private:
     void OnInitialise() override final;
     void OnConfigure() override final;
@@ -58,11 +51,7 @@ namespace eudaq {
     void OnReset() override final;
     void OnTerminate() override final;
     void OnStatus() override final;
-
-    // void OnConnect(ConnectionSPC id) override final;
-    // void OnDisconnect(ConnectionSPC id) override final;
     void OnReceive(ConnectionSPC id, EventSP ev) override final;
-    
   private:
     std::string m_data_addr;
   };

--- a/main/lib/core/include/eudaq/Monitor.hh
+++ b/main/lib/core/include/eudaq/Monitor.hh
@@ -47,6 +47,7 @@ namespace eudaq {
     virtual void DoStopRun(){};
     virtual void DoReset(){};
     virtual void DoTerminate(){};
+    virtual void DoStatus(){};
 
     //running in dataserver thread
     virtual void DoReceive(EventSP ev){};

--- a/main/lib/core/include/eudaq/Monitor.hh
+++ b/main/lib/core/include/eudaq/Monitor.hh
@@ -54,6 +54,7 @@ namespace eudaq {
     void OnReceive(ConnectionSPC id, EventSP ev) override final;
   private:
     std::string m_data_addr;
+    uint32_t m_evt_c;
   };
   //----------DOC-MARK-----END*DEC-----DOC-MARK----------
 }

--- a/main/lib/core/include/eudaq/Monitor.hh
+++ b/main/lib/core/include/eudaq/Monitor.hh
@@ -1,8 +1,8 @@
 #ifndef EUDAQ_INCLUDED_Monitor
 #define EUDAQ_INCLUDED_Monitor
 
-#include "eudaq/TransportServer.hh"
 #include "eudaq/CommandReceiver.hh"
+#include "eudaq/DataReceiver.hh"
 #include "eudaq/Event.hh"
 #include "eudaq/Configuration.hh"
 #include "eudaq/Utils.hh"
@@ -28,7 +28,7 @@ namespace eudaq {
   using MonitorSP = Factory<Monitor>::SP_BASE;
   
   //----------DOC-MARK-----BEG*DEC-----DOC-MARK----------
-  class DLLEXPORT Monitor : public CommandReceiver {
+  class DLLEXPORT Monitor : public CommandReceiver, public DataReceiver{
   public:
     Monitor(const std::string &name, const std::string &runcontrol);
     void OnInitialise() override final;

--- a/main/lib/core/include/eudaq/Producer.hh
+++ b/main/lib/core/include/eudaq/Producer.hh
@@ -20,6 +20,8 @@ namespace eudaq {
 	   (const std::string&, const std::string&)>&
   Factory<Producer>::Instance<const std::string&, const std::string&>();  
 #endif
+
+  using ProducerSP = Factory<Producer>::SP_BASE;
   
   /**
    * The base class from which all Producers should inherit.
@@ -46,6 +48,8 @@ namespace eudaq {
     virtual void DoTerminate(){};
     
     void SendEvent(EventSP ev);
+    static ProducerSP Make(const std::string &code_name, const std::string &run_name,
+			   const std::string &runcontrol);
   private:
     uint32_t m_pdc_n;
     uint32_t m_evt_c;

--- a/main/lib/core/include/eudaq/Producer.hh
+++ b/main/lib/core/include/eudaq/Producer.hh
@@ -32,14 +32,6 @@ namespace eudaq {
   class DLLEXPORT Producer : public CommandReceiver{
   public:
     Producer(const std::string &name, const std::string &runcontrol);
-    void OnInitialise() override final;
-    void OnConfigure() override final;
-    void OnStartRun() override final;
-    void OnStopRun() override final;
-    void OnReset() override final;
-    void OnTerminate() override final;
-    void OnStatus() override;
-    void Exec() override;
 
     virtual void DoInitialise(){};
     virtual void DoConfigure(){};
@@ -52,6 +44,16 @@ namespace eudaq {
     void SendEvent(EventSP ev);
     static ProducerSP Make(const std::string &code_name, const std::string &run_name,
 			   const std::string &runcontrol);
+
+  private:
+    void OnInitialise() override final;
+    void OnConfigure() override final;
+    void OnStartRun() override final;
+    void OnStopRun() override final;
+    void OnReset() override final;
+    void OnTerminate() override final;
+    void OnStatus() override;
+    
   private:
     uint32_t m_pdc_n;
     uint32_t m_evt_c;

--- a/main/lib/core/include/eudaq/Producer.hh
+++ b/main/lib/core/include/eudaq/Producer.hh
@@ -38,6 +38,7 @@ namespace eudaq {
     void OnStopRun() override final;
     void OnReset() override final;
     void OnTerminate() override final;
+    void OnStatus() override;
     void Exec() override;
 
     virtual void DoInitialise(){};
@@ -46,6 +47,7 @@ namespace eudaq {
     virtual void DoStopRun(){};
     virtual void DoReset(){};
     virtual void DoTerminate(){};
+    virtual void DoStatus(){};
     
     void SendEvent(EventSP ev);
     static ProducerSP Make(const std::string &code_name, const std::string &run_name,

--- a/main/lib/core/include/eudaq/Status.hh
+++ b/main/lib/core/include/eudaq/Status.hh
@@ -9,8 +9,7 @@
 #include <map>
 #include <ostream>
 
-namespace eudaq {
-
+namespace eudaq{
   class Serializer;
   class Deserializer;
   class Status;
@@ -32,7 +31,6 @@ namespace eudaq {
       LVL_USER,
       LVL_NONE // The last value, any additions should go before this
     };
-
     enum State {
       STATE_ERROR,
       STATE_UNINIT,
@@ -41,27 +39,23 @@ namespace eudaq {
       STATE_RUNNING
     };
     
-    Status(int level = LVL_OK, const std::string &msg = "")
-      : m_level(level), m_state(STATE_UNINIT), m_msg(msg) {}
-    
-
+    Status(int lvl = LVL_OK, const std::string &msg = "");
     Status(Deserializer &);
+    ~Status() override;
     void Serialize(Serializer &) const override;
-
-    void ResetStatus(State st, Level lvl, const std::string &msg);
-    int GetLevel() const { return m_level;}
-    int GetState() const { return m_state;}
-    std::string GetStateString()const;
-    std::string GetMessage() const {return m_msg;}
-    
-    Status &SetTag(const std::string &name, const std::string &val);
-    std::string GetTag(const std::string &name,
-                       const std::string &def = "") const;
-    std::map<std::string, std::string> GetTags() const {return m_tags;};
-    
-    static std::string Level2String(int level);
-    static int String2Level(const std::string &);
     virtual void Print(std::ostream &os, size_t offset = 0) const;
+    void ResetStatus(State st, Level lvl, const std::string &msg);
+    void SetMessage(const std::string &msg);
+    void SetTag(const std::string &key, const std::string &val);
+    int GetLevel() const;
+    int GetState() const;
+    std::string GetMessage() const;
+    std::string GetStateString()const;
+    std::string GetTag(const std::string &key,
+                       const std::string &val= "") const;
+    std::map<std::string, std::string> GetTags() const;
+    static std::string Level2String(int lvl);
+    static int String2Level(const std::string &str);
   private:
     int m_level;
     int m_state;
@@ -71,10 +65,6 @@ namespace eudaq {
     static std::map<uint32_t, std::string> m_map_level_str;
   };
 
-  inline std::ostream &operator<<(std::ostream &os, const Status &s) {
-    s.Print(os);
-    return os;
-  }
 }
 
 #endif // EUDAQ_INCLUDED_Status

--- a/main/lib/core/include/eudaq/TransportBase.hh
+++ b/main/lib/core/include/eudaq/TransportBase.hh
@@ -133,11 +133,17 @@ namespace eudaq {
     TransportCallback(const TransportCallback &other)
         : m_helper(other.m_helper->Clone()) {}
     TransportCallback &operator=(const TransportCallback &other) {
-      delete m_helper;
+      if(m_helper){
+	delete m_helper;
+      }
       m_helper = other.m_helper->Clone();
       return *this;
     }
-    ~TransportCallback() { delete m_helper; }
+    ~TransportCallback() {
+      if(m_helper){
+	delete m_helper;
+      }
+    }
 
   private:
     Helper *m_helper; ///< The helper class to perform the actual function call

--- a/main/lib/core/include/eudaq/TransportBase.hh
+++ b/main/lib/core/include/eudaq/TransportBase.hh
@@ -63,11 +63,11 @@ namespace eudaq {
   class DLLEXPORT TransportEvent {
   public:
     enum EventType { CONNECT, DISCONNECT, RECEIVE };
-    TransportEvent(EventType et, std::shared_ptr<ConnectionInfo> i, const std::string &p = "")
+    TransportEvent(EventType et, ConnectionSP i, const std::string &p = "")
         : etype(et), id(i), packet(p) {}
     TransportEvent & operator = (const TransportEvent& rh){etype = rh.etype; id=rh.id;  packet = rh.packet; return *this;};
-    EventType etype;    ///< The type of event
-    std::shared_ptr<ConnectionInfo> id; ///< The id of the connection  !! It is reference!! TODO: CHECK
+    EventType etype; ///< The type of event
+    ConnectionSP id; ///< The id of the connection
     std::string packet; ///< The packet of data in case of a RECEIVE event
   };
 

--- a/main/lib/core/include/eudaq/TransportTCP_POSIX.hh
+++ b/main/lib/core/include/eudaq/TransportTCP_POSIX.hh
@@ -9,6 +9,66 @@
 #define INVALID_SOCKET -1
 #endif
 
+
+// defining error code more informations under
+// http://www.gnu.org/software/libc/manual/html_node/Error-Codes.html
+
+// Redirection to EAGAIN
+//
+// Quate:
+// 	"Resource temporarily unavailable; the call might work if you
+// 	try again later. The macro EWOULDBLOCK is another name for EAGAIN;
+// 	they are always the same in the GNU C Library.
+//
+// 	This error can happen in a few different situations:
+//
+// 	An operation that would block was attempted on an object
+// 	that has non-blocking mode selected. Trying the same operation
+// 	again will block until some external condition makes it possible
+// 	to read, write, or connect (whatever the operation). You can
+// 	use select to find out when the operation will be possible;
+// 	see Waiting for I/O.
+//
+// 	Portability Note: In many older Unix systems, this condition
+// 	was indicated by EWOULDBLOCK, which was a distinct error code
+// 	different from EAGAIN. To make your program portable, you
+// 	should check for both codes and treat them the same.
+// 	A temporary resource shortage made an operation impossible.
+// 	fork can return this error. It indicates that the shortage
+// 	is expected to pass, so your program can try the call again
+// 	later and it may succeed. It is probably a good idea to delay
+// 	for a few seconds before trying it again, to allow time for
+// 	other processes to release scarce resources. Such
+// 	shortages are usually fairly serious and affect the whole
+// 	system, so usually an interactive program should report
+// 	the error to the user and return to its command loop. "
+#define EUDAQ_ERROR_Resource_temp_unavailable EWOULDBLOCK
+
+// 	An operation that cannot complete immediately was initiated
+// 	on an object that has non-blocking mode selected. Some
+// 	functions that must always block (such as connect; see
+// 	Connecting) never return EAGAIN. Instead, they return
+// 	EINPROGRESS to indicate that the operation has begun and
+// 	will take some time. Attempts to manipulate the object
+// 	before the call completes return EALREADY. You can use the
+// 	select function to find out when the pending operation has
+// 	completed; see Waiting for I/O.
+#define EUDAQ_ERROR_Operation_progress EINPROGRESS
+
+// 	Interrupted function call;
+// 	an asynchronous signal occurred and
+// 	prevented completion of the call.
+// 	When this happens, you should try
+// 	the call again.
+// 	You can choose to have functions resume
+// 	after a signal that is handled, rather
+// 	than failing with EINTR; see Interrupted
+// 	Primitives.
+#define EUDAQ_ERROR_Interrupted_function_call EINTR
+
+#define EUDAQ_ERROR_NO_DATA_RECEIVED -1
+
+
 namespace eudaq {
 
   namespace {

--- a/main/lib/core/include/eudaq/TransportTCP_WIN32.hh
+++ b/main/lib/core/include/eudaq/TransportTCP_WIN32.hh
@@ -14,8 +14,40 @@
 
 #include <map>
 
-namespace eudaq {
+// defining error code more informations under
+// http://msdn.microsoft.com/en-us/library/windows/desktop/ms740668%28v=vs.85%29.aspx
 
+// qute:
+// "Resource temporarily unavailable.
+//
+// 	This error is returned from operations on nonblocking sockets that
+//  cannot be completed immediately, for example recv when no data is queued
+//  to be read from the socket. It is a nonfatal error, and the operation
+//  should be retried later. It is normal for WSAEWOULDBLOCK to be reported
+//  as the result from calling connect on a nonblocking SOCK_STREAM socket,
+//  since some time must elapse for the connection to be established."
+#define EUDAQ_ERROR_Resource_temp_unavailable WSAEWOULDBLOCK
+
+// qute:
+// Operation now in progress.
+//
+// 	A blocking operation is currently executing. Windows Sockets
+// 	only allows a single blocking operation (per- task or thread) to
+// 	be outstanding, and if any other function call is made (whether
+// 	or not it references that or any other socket) the function fails
+// 	with the WSAEINPROGRESS error.
+//
+#define EUDAQ_ERROR_Operation_progress WSAEINPROGRESS
+
+// Interrupted function call.
+//	A blocking operation was interrupted by a call to WSACancelBlockingCall.
+//
+#define EUDAQ_ERROR_Interrupted_function_call WSAEINTR
+
+#define EUDAQ_ERROR_NO_DATA_RECEIVED -1
+
+
+namespace eudaq {
   namespace {
 
     // List of Winsock error constants mapped to an interpretation string.

--- a/main/lib/core/include/eudaq/Utils.hh
+++ b/main/lib/core/include/eudaq/Utils.hh
@@ -153,11 +153,6 @@ namespace eudaq {
     return static_cast<uint16_t>(from_string(x, (uint64_t)def));
   }
   
-  template <typename T> struct Holder {
-    Holder(T val) : m_val(val) {}
-    T m_val;
-  };
-
   template <typename T> struct hexdec_t {
     enum { DIGITS = 2 * sizeof(T) };
     hexdec_t(T val, unsigned hexdigits) : m_val(val), m_dig(hexdigits) {}

--- a/main/lib/core/src/CommandReceiver.cc
+++ b/main/lib/core/src/CommandReceiver.cc
@@ -117,6 +117,26 @@ namespace eudaq {
     EUDAQ_INFO(GetFullName() + " is terminated.");
   }
 
+  void CommandReceiver::OnStatus(){
+
+  }
+  
+  void CommandReceiver::OnUnrecognised(const std::string & /*cmd*/, const std::string & /*param*/){
+
+  }
+
+
+  std::string CommandReceiver::GetFullName() const {return m_type+"."+m_name;}
+  std::string CommandReceiver::GetName() const {return m_name;}
+  uint32_t CommandReceiver::GetRunNumber() const {return m_run_number;}
+  std::string CommandReceiver::GetCommandRecieverAddress() const {return m_addr_client;}
+    
+  ConfigurationSPC CommandReceiver::GetConfiguration() const {return m_conf;}
+  ConfigurationSPC CommandReceiver::GetInitConfiguration() const {return m_conf_init;}
+
+  bool CommandReceiver::IsConnected(){return m_is_connected;}
+  void CommandReceiver::StartCommandReceiver(){Connect();}
+  bool CommandReceiver::IsActiveCommandReceiver(){return m_is_connected;}
   
   bool CommandReceiver::RunLoop(){
     return 0;
@@ -211,7 +231,8 @@ namespace eudaq {
     return 0;
   }
   
-  std::string CommandReceiver::Connect(const std::string &addr){
+  std::string CommandReceiver::Connect(){
+    std::string addr = m_addr_runctrl;
     std::unique_lock<std::mutex> lk_deamon(m_mx_deamon);
     if(m_cmdclient){
       EUDAQ_THROW("command receiver is not closed before");
@@ -314,13 +335,6 @@ namespace eudaq {
     }
     catch(...){
       EUDAQ_WARN("connection execption from disconnetion");
-    }
-  }
-
-  void CommandReceiver::Exec(){
-    Connect();
-    while(IsConnected()){
-      std::this_thread::sleep_for(std::chrono::milliseconds(1000));
     }
   }
   

--- a/main/lib/core/src/CommandReceiver.cc
+++ b/main/lib/core/src/CommandReceiver.cc
@@ -165,7 +165,7 @@ namespace eudaq {
   }
   
   bool CommandReceiver::AsyncReceiving(){
-    std::cout<<"AsyncReceiving >>>> enter"<<std::endl;
+    // std::cout<<"AsyncReceiving >>>> enter"<<std::endl;
     try{
       while(m_is_connected){
 	m_cmdclient->Process(-1); //how long does it wait?
@@ -178,14 +178,14 @@ namespace eudaq {
   }
 
   bool CommandReceiver::AsyncForwarding(){
-    std::cout<<"AsyncForwding >>>> enter"<<std::endl;
+    // std::cout<<"AsyncForwding >>>> enter"<<std::endl;
     while(m_is_connected){
       std::unique_lock<std::mutex> lk(m_mx_qu_cmd);
       if(m_qu_cmd.empty()){
 	// std::cout<<"AsyncForwding >>>> waiting empty"<<std::endl;
 	while(m_cv_not_empty.wait_for(lk, std::chrono::seconds(1))==std::cv_status::timeout){
 	  if(!m_is_connected){
-	    std::cout<<"AysncForwarding << << << return"<<std::endl;
+	    // std::cout<<"AysncForwarding << << << return"<<std::endl;
 	    return 0;
 	  }
 	}
@@ -304,7 +304,7 @@ namespace eudaq {
   }
 
   bool CommandReceiver::Deamon(){
-    std::cout<<"Deamon >>>> enter"<<std::endl;
+    // std::cout<<"Deamon >>>> enter"<<std::endl;
     while(!m_is_destructing){
       // std::cout<<">>> Deamon Loop"<<std::endl;
       std::this_thread::sleep_for(std::chrono::milliseconds(200));
@@ -330,7 +330,7 @@ namespace eudaq {
       }
       else{
 	try{
-	  std::cout<<">>>>>>>>>exiting"<<std::endl;
+	  // std::cout<<">>>>>>>>>exiting"<<std::endl;
 	  if(m_fut_async_rcv.valid()){
 	    m_fut_async_rcv.get();
 	  }
@@ -339,7 +339,7 @@ namespace eudaq {
 	  }
 	  m_cmdclient.reset();
 	  //TODO: clear queue
-	  std::cout<<">>>>>>>>>exit"<<std::endl;
+	  // std::cout<<">>>>>>>>>exit"<<std::endl;
 	}
 	catch(...){
 	  EUDAQ_WARN("connection execption from disconnetion");
@@ -347,7 +347,7 @@ namespace eudaq {
       }
     }
     try{
-      std::cout<<">>>>>>>>>exiting--"<<std::endl;
+      // std::cout<<">>>>>>>>>exiting--"<<std::endl;
       std::unique_lock<std::mutex> lk_deamon(m_mx_deamon);
       m_is_connected = false;
       if(m_fut_async_rcv.valid()){
@@ -357,7 +357,7 @@ namespace eudaq {
 	m_fut_async_fwd.get();
       }
       m_cmdclient.reset();
-      std::cout<<">>>>>>>>>exit--"<<std::endl;
+      // std::cout<<">>>>>>>>>exit--"<<std::endl;
     }
     catch(...){
       EUDAQ_WARN("connection execption from disconnetion");

--- a/main/lib/core/src/CommandReceiver.cc
+++ b/main/lib/core/src/CommandReceiver.cc
@@ -166,10 +166,14 @@ namespace eudaq {
 	m_cmdclient->Process(-1); //how long does it wait?
       }
     } catch (const std::exception &e) {
-      //TODO: move the catch to up level
-      std::cout <<"CommandReceiver::AsyncReceiving Error: Uncaught exception: " <<e.what() <<std::endl;
+      //TODO: move the catch to up leve
+      EUDAQ_ERROR(std::string("CommandReceiver::AsyncReceiving Error: Uncaught exception: ")+ e.what());
+      m_is_connected = false;
+      throw;
     } catch (...) {
-      std::cout <<"CommandReceiver::AsyncReceiving Error: Uncaught unrecognised exception" <<std::endl;
+      EUDAQ_ERROR(std::string("CommandReceiver::AsyncReceiving Error: Uncaught unrecognised exception"));
+      m_is_connected = false;
+      throw;
     }
   }
 
@@ -321,8 +325,8 @@ namespace eudaq {
 	  if(m_fut_async_fwd.valid()){
 	    m_fut_async_fwd.get();
 	  }
+	  m_qu_cmd =  std::queue<std::pair<std::string, std::string>>();
 	  m_cmdclient.reset();
-	  //TODO: clear queue
 	}
 	catch(...){
 	  EUDAQ_WARN("connection execption from disconnetion");

--- a/main/lib/core/src/CommandReceiver.cc
+++ b/main/lib/core/src/CommandReceiver.cc
@@ -87,6 +87,12 @@ namespace eudaq {
   }
 
   void CommandReceiver::OnInitialise(){
+    // std::string cur_backup = GetInitConfiguration()->GetCurrentSectionName();
+    // GetInitConfiguration()->SetSection("");
+    // std::string log_addr = GetInitConfiguration()->Get("EUDAQ_LOG_ADDR", "");
+    // if(!log_addr.empty())
+    //   EUDAQ_LOG_CONNECT(m_type, m_name, log_addr);
+    // GetInitConfiguration()->SetSection(cur_backup);
     SetStatus(Status::STATE_UNCONF, "Initialized");
     EUDAQ_INFO(GetFullName() + " is initialised.");
   }
@@ -98,7 +104,7 @@ namespace eudaq {
   
   void CommandReceiver::OnStartRun(){
     if(m_fut_runloop.valid()){
-      EUDAQ_THROW("Last run is not stoped");
+      EUDAQ_THROW("CommandReceiver: Last run is not stoped");
     }
     m_is_runlooping = true;
     m_fut_runloop = std::async(std::launch::async, &CommandReceiver::RunLooping, this);
@@ -117,7 +123,7 @@ namespace eudaq {
 	SetStatusMsg(msg);
 	SendStatus();
 	if((std::chrono::steady_clock::now()-tp_user_return) > std::chrono::seconds(20)){
-	  EUDAQ_THROW("CommandReceiver:: Unable to stop the user's RunLoop");
+	  EUDAQ_THROW("CommandReceiver: Unable to stop the user's RunLoop");
 	}
       }
       m_fut_runloop.get();
@@ -137,12 +143,12 @@ namespace eudaq {
 	SetStatusMsg(msg);
 	SendStatus();
 	if((std::chrono::steady_clock::now()-tp_user_return) > std::chrono::seconds(20)){
-	  EUDAQ_THROW("CommandReceiver:: Unable to stop the user's RunLoop");
+	  EUDAQ_THROW("CommandReceiver: Unable to stop the user's RunLoop");
 	}
       }
       m_fut_runloop.get();
     }
-    SetStatus(Status::STATE_UNINIT, "Reseted");
+    SetStatus(Status::STATE_UNINIT, "Reset");
     EUDAQ_INFO(GetFullName() + " is reset.");
   }
 
@@ -219,11 +225,11 @@ namespace eudaq {
       }
     } catch (const std::exception &e) {
       //TODO: move the catch to up level
-      EUDAQ_ERROR(std::string("CommandReceiver::AsyncReceiving Error: Uncaught exception: ")+ e.what());
+      EUDAQ_ERROR(std::string("CommandReceiver: AsyncReceiving Error: Uncaught exception: ")+ e.what());
       m_is_connected = false;
       throw;
     } catch (...) {
-      EUDAQ_ERROR(std::string("CommandReceiver::AsyncReceiving Error: Uncaught unrecognised exception"));
+      EUDAQ_ERROR(std::string("CommandReceiver: AsyncReceiving Error: Uncaught unrecognised exception"));
       m_is_connected = false;
       throw;
     }
@@ -291,7 +297,7 @@ namespace eudaq {
     std::unique_lock<std::mutex> lk_deamon(m_mx_deamon);
 
     if(m_cmdclient){
-      EUDAQ_THROW("command receiver is not closed before");
+      EUDAQ_THROW("CommandReceiver: Command receiver is not closed before");
     }
     
     auto cmdclient = TransportClient::CreateClient(m_addr_runctrl);
@@ -359,7 +365,7 @@ namespace eudaq {
 	  }
 	}
 	catch(...){
-	  EUDAQ_WARN("connection execption from disconnetion");
+	  EUDAQ_WARN("CommandReceiver: Connection execption from disconnetion");
 	}
       }
       else{
@@ -374,7 +380,7 @@ namespace eudaq {
 	  m_cmdclient.reset();
 	}
 	catch(...){
-	  EUDAQ_WARN("connection execption from disconnetion");
+	  EUDAQ_WARN("CommandReceiver: connection execption from disconnetion");
 	}
       }
     }
@@ -391,7 +397,7 @@ namespace eudaq {
 	m_cmdclient.reset();
     }
     catch(...){
-      EUDAQ_WARN("connection execption from disconnetion");
+      EUDAQ_WARN("CommandReceiver: connection execption from disconnetion");
     }
   }
   

--- a/main/lib/core/src/DataCollector.cc
+++ b/main/lib/core/src/DataCollector.cc
@@ -19,8 +19,41 @@ namespace eudaq {
     m_exit = false;
   }
 
-  DataCollector::~DataCollector(){
-    
+  DataCollector::~DataCollector(){  
+  }
+
+  void DataCollector::DoInitialise(){
+  }
+  
+  void DataCollector::DoConfigure(){
+  }
+  
+  void DataCollector::DoStartRun(){
+  }
+  
+  void DataCollector::DoStopRun(){
+  }
+  
+  void DataCollector::DoReset(){
+  }
+  
+  void DataCollector::DoTerminate(){
+  }
+  
+  void DataCollector::DoStatus(){
+  }
+
+  void DataCollector::DoConnect(ConnectionSPC id){
+  }
+  
+  void DataCollector::DoDisconnect(ConnectionSPC id){
+  }
+  
+  void DataCollector::DoReceive(ConnectionSPC id, EventSP ev){
+  }
+
+  void DataCollector::SetServerAddress(const std::string &addr){
+    m_data_addr = addr;
   }
   
   void DataCollector::OnInitialise(){

--- a/main/lib/core/src/DataCollector.cc
+++ b/main/lib/core/src/DataCollector.cc
@@ -124,6 +124,7 @@ namespace eudaq {
     try {
       DoStopRun();
       m_senders.clear();
+      StopListen();
       CommandReceiver::OnStopRun();
     } catch (const Exception &e) {
       std::string msg = "Error stopping for run " + std::to_string(GetRunNumber()) + ": " + e.what();

--- a/main/lib/core/src/DataCollector.cc
+++ b/main/lib/core/src/DataCollector.cc
@@ -277,4 +277,13 @@ namespace eudaq {
       std::this_thread::sleep_for(std::chrono::milliseconds(500));
     }
   }
+
+  DataCollectorSP DataCollector::Make(const std::string &code_name,
+				      const std::string &run_name,
+				      const std::string &runcontrol){
+    return Factory<DataCollector>::
+      MakeShared<const std::string&,const std::string&>
+      (eudaq::str2hash(code_name), run_name, runcontrol);
+  }
+
 }

--- a/main/lib/core/src/DataCollector.cc
+++ b/main/lib/core/src/DataCollector.cc
@@ -17,11 +17,10 @@ namespace eudaq {
     m_dct_n= str2hash(GetFullName());
     m_evt_c = 0;
     m_exit = false;
-    Connect(runcontrol);
   }
 
   DataCollector::~DataCollector(){
-
+    
   }
   
   void DataCollector::OnInitialise(){
@@ -32,8 +31,7 @@ namespace eudaq {
       SetStatusTag("_SERVER", m_data_addr);
       StopListen();
       DoInitialise();
-      SetStatus(Status::STATE_UNCONF, "Initialized");
-      EUDAQ_INFO(GetFullName() + " is initialised.");
+      CommandReceiver::OnInitialise();
     }catch (const Exception &e) {
       std::string msg = "Error when init by " + conf->Name() + ": " + e.what();
       EUDAQ_ERROR(msg);
@@ -50,8 +48,7 @@ namespace eudaq {
       m_fwpatt = conf->Get("EUDAQ_FW_PATTERN", "$12D_run$6R$X");
       m_dct_n = conf->Get("EUDAQ_ID", m_dct_n);
       DoConfigure();
-      SetStatus(Status::STATE_CONF, "Configured");
-      EUDAQ_INFO(GetFullName() + " is configured.");
+      CommandReceiver::OnConfigure();
     }catch (const Exception &e) {
       std::string msg = "Error when configuring by " + conf->Name() + ": " + e.what();
       EUDAQ_ERROR(msg);
@@ -81,8 +78,7 @@ namespace eudaq {
       }
       GetConfiguration()->SetSection(cur_backup);
       DoStartRun();
-      SetStatus(Status::STATE_RUNNING, "Started");
-      EUDAQ_INFO("RUN #" + std::to_string(GetRunNumber()) + " is started.");
+      CommandReceiver::OnStartRun();
     } catch (const Exception &e) {
       std::string msg = "Error preparing for run " + std::to_string(GetRunNumber()) + ": " + e.what();
       EUDAQ_ERROR(msg);
@@ -95,8 +91,7 @@ namespace eudaq {
     try {
       DoStopRun();
       m_senders.clear();
-      SetStatus(Status::STATE_CONF, "Stopped");
-      EUDAQ_INFO("RUN #" + std::to_string(GetRunNumber()) + " is stopped.");
+      CommandReceiver::OnStopRun();
     } catch (const Exception &e) {
       std::string msg = "Error stopping for run " + std::to_string(GetRunNumber()) + ": " + e.what();
       EUDAQ_ERROR(msg);
@@ -109,8 +104,7 @@ namespace eudaq {
     try{
       DoReset();
       m_senders.clear();
-      SetStatus(Status::STATE_UNINIT, "Reset");
-      EUDAQ_INFO(GetFullName() + " is reset.");
+      CommandReceiver::OnReset();
     } catch (const std::exception &e) {
       EUDAQ_THROW( std::string("DataCollector Reset:: Caught exception: ") + e.what() );
       SetStatus(Status::STATE_ERROR, "Reset Error");
@@ -123,8 +117,7 @@ namespace eudaq {
   void DataCollector::OnTerminate(){
     EUDAQ_INFO(GetFullName() + " is to be terminated...");
     DoTerminate();
-    SetStatus(Status::STATE_UNINIT, "Terminated");
-    EUDAQ_INFO(GetFullName() + " is terminated.");
+    CommandReceiver::OnTerminate();
   }
     
   void DataCollector::OnStatus(){
@@ -179,12 +172,6 @@ namespace eudaq {
     }
   }
   
-  void DataCollector::Exec(){
-    // while(IsActiveCommandReceiver()){
-    //   std::this_thread::sleep_for(std::chrono::milliseconds(500));
-    // }
-    std::cout<<">>>>>>>>>>>>>>>> end of exec"<<std::endl;
-  }
 
   DataCollectorSP DataCollector::Make(const std::string &code_name,
 				      const std::string &run_name,

--- a/main/lib/core/src/DataCollector.cc
+++ b/main/lib/core/src/DataCollector.cc
@@ -6,7 +6,6 @@
 #include <ctime>
 #include <iomanip>
 namespace eudaq {
-
   template class DLLEXPORT Factory<DataCollector>;
   template DLLEXPORT std::map<uint32_t, typename Factory<DataCollector>::UP_BASE (*)
 			      (const std::string&, const std::string&)>&
@@ -16,7 +15,6 @@ namespace eudaq {
     :CommandReceiver("DataCollector", name, runcontrol){
     m_dct_n= str2hash(GetFullName());
     m_evt_c = 0;
-    m_exit = false;
   }
 
   DataCollector::~DataCollector(){  
@@ -138,6 +136,7 @@ namespace eudaq {
     try{
       DoReset();
       m_senders.clear();
+      StopListen();
       CommandReceiver::OnReset();
     } catch (const std::exception &e) {
       EUDAQ_THROW( std::string("DataCollector Reset:: Caught exception: ") + e.what() );
@@ -205,7 +204,6 @@ namespace eudaq {
       SetStatus(Status::STATE_ERROR, msg);
     }
   }
-  
 
   DataCollectorSP DataCollector::Make(const std::string &code_name,
 				      const std::string &run_name,

--- a/main/lib/core/src/DataCollector.cc
+++ b/main/lib/core/src/DataCollector.cc
@@ -61,6 +61,7 @@ namespace eudaq {
       m_data_addr = Listen(m_data_addr);
       SetStatusTag("_SERVER", m_data_addr);
       StopListen();
+      SendStatus();
       DoInitialise();
       CommandReceiver::OnInitialise();
     }catch (const Exception &e) {
@@ -184,7 +185,6 @@ namespace eudaq {
       
       ev->SetRunN(GetRunNumber());
       ev->SetEventN(m_evt_c);
-      SetStatusTag("EventN", std::to_string(m_evt_c));
       m_evt_c ++;
       ev->SetStreamN(m_dct_n);
       if(m_writer)

--- a/main/lib/core/src/DataCollector.cc
+++ b/main/lib/core/src/DataCollector.cc
@@ -253,13 +253,12 @@ namespace eudaq {
       EUDAQ_THROW("DataCollector can not be restarted after exit. (TODO)");
     }
     if(m_data_addr.empty()){
-      m_data_addr = "tcp://";
-      uint16_t port = static_cast<uint16_t>(GetCommandReceiverID()) + 1024;
-      m_data_addr += to_string(port);
+      m_data_addr = "tcp://0";
     }
     m_dataserver.reset(TransportServer::CreateServer(m_data_addr));
     m_dataserver->SetCallback(TransportCallback(this, &DataCollector::DataHandler));
     m_thd_server = std::thread(&DataCollector::DataThread, this);
+    m_data_addr = m_dataserver->ConnectionString();
     SetStatusTag("_SERVER", m_data_addr);
   }
 

--- a/main/lib/core/src/DataCollector.cc
+++ b/main/lib/core/src/DataCollector.cc
@@ -125,6 +125,7 @@ namespace eudaq {
     
   void DataCollector::OnStatus(){
     SetStatusTag("EventN", std::to_string(m_evt_c));
+    DoStatus();
     if(m_writer && m_writer->FileBytes()){
       SetStatusTag("FILEBYTES", std::to_string(m_writer->FileBytes()));
     }
@@ -213,14 +214,13 @@ namespace eudaq {
       SetStatusTag("EventN", std::to_string(m_evt_c));
       m_evt_c ++;
       ev->SetStreamN(m_dct_n);
-      EventSP evsp(std::move(ev));
       if(m_writer)
-	m_writer->WriteEvent(evsp);
+	m_writer->WriteEvent(ev);
       else
 	EUDAQ_THROW("FileWriter is not created before writing.");
       for(auto &e: m_senders){
 	if(e.second)
-	  e.second->SendEvent(*(evsp.get()));
+	  e.second->SendEvent(ev);
 	else
 	  EUDAQ_THROW("DataCollector::WriterEvent, using a null pointer of DataSender");
       }
@@ -285,5 +285,4 @@ namespace eudaq {
       MakeShared<const std::string&,const std::string&>
       (eudaq::str2hash(code_name), run_name, runcontrol);
   }
-
 }

--- a/main/lib/core/src/DataReceiver.cc
+++ b/main/lib/core/src/DataReceiver.cc
@@ -154,8 +154,6 @@ namespace eudaq {
     if(!addr.empty()){
       this_addr = addr;
     }
-
-    std::cout<< "DataReceiver<<<<<<<<<listen enter"<<std::endl;
     if(m_dataserver){
       EUDAQ_THROW("last server did not closed sucessfully");
     }
@@ -207,7 +205,7 @@ namespace eudaq {
 	  }
 	  m_qu_ev = std::queue<std::pair<EventSP, ConnectionSPC>>();
 	  m_dataserver.reset();
-	  std::cout<<"m_dataServer reset"<<std::endl;
+	  // std::cout<<"m_dataServer reset"<<std::endl;
 	}
 	catch(...){
 	  EUDAQ_WARN("connection execption from disconnetion");

--- a/main/lib/core/src/DataReceiver.cc
+++ b/main/lib/core/src/DataReceiver.cc
@@ -1,0 +1,192 @@
+#include "eudaq/DataReceiver.hh"
+#include "eudaq/TransportServer.hh"
+#include "eudaq/BufferSerializer.hh"
+#include "eudaq/Logger.hh"
+#include "eudaq/Utils.hh"
+#include <iostream>
+#include <ostream>
+#include <ctime>
+#include <iomanip>
+namespace eudaq {
+  
+  DataReceiver::DataReceiver()
+    :m_is_listening(false),m_is_destructing(false){
+    m_fut_deamon = std::async(std::launch::async, &DataReceiver::Deamon, this); 
+  }
+
+  DataReceiver::~DataReceiver(){
+    m_is_destructing = true;
+    if(m_fut_deamon.valid()){
+      m_fut_deamon.get();
+    }
+  }
+
+  void DataReceiver::OnConnect(ConnectionSPC id){
+  }
+  
+  void DataReceiver::OnDisconnect(ConnectionSPC id){
+  }
+  
+  void DataReceiver::OnReceive(ConnectionSPC id, EventSP ev){
+  }
+  
+  void DataReceiver::DataHandler(TransportEvent &ev) {
+    auto con = ev.id;
+    switch (ev.etype) {
+    case (TransportEvent::CONNECT):
+      m_dataserver->SendPacket("OK EUDAQ DATA DataReceiver", *con, true);
+      break;
+    case (TransportEvent::DISCONNECT):
+      con->SetState(0);
+      EUDAQ_INFO("Disconnected: " + to_string(*con));
+      for (size_t i = 0; i < m_vt_con.size(); ++i){
+	if (m_vt_con[i] == con){
+	  m_vt_con.erase(m_vt_con.begin() + i);
+	  std::unique_lock<std::mutex> lk(m_mx_qu_ev);
+	  m_qu_ev.push(std::make_pair<EventSP, ConnectionSPC>(nullptr, con));
+	}
+      }
+      EUDAQ_THROW("Unrecognised connection id");
+      break;
+    case (TransportEvent::RECEIVE):
+      if (con->GetState() == 0) { //unidentified connection
+        do {
+          size_t i0 = 0, i1 = ev.packet.find(' ');
+          if (i1 == std::string::npos)
+            break;
+          std::string part(ev.packet, i0, i1);
+          if (part != "OK")
+            break;
+          i0 = i1 + 1;
+          i1 = ev.packet.find(' ', i0);
+          if (i1 == std::string::npos)
+            break;
+          part = std::string(ev.packet, i0, i1 - i0);
+          if (part != "EUDAQ")
+            break;
+          i0 = i1 + 1;
+          i1 = ev.packet.find(' ', i0);
+          if (i1 == std::string::npos)
+            break;
+          part = std::string(ev.packet, i0, i1 - i0);
+          if (part != "DATA")
+            break;
+          i0 = i1 + 1;
+          i1 = ev.packet.find(' ', i0);
+          part = std::string(ev.packet, i0, i1 - i0);
+          con->SetType(part);
+          i0 = i1 + 1;
+          i1 = ev.packet.find(' ', i0);
+          part = std::string(ev.packet, i0, i1 - i0);
+          con->SetName(part);
+        } while (false);
+        m_dataserver->SendPacket("OK", *con, true);
+        con->SetState(1); // successfully identified
+	EUDAQ_INFO("Connection from " + to_string(*con));
+	m_vt_con.push_back(con);
+	std::unique_lock<std::mutex> lk(m_mx_qu_ev);
+	m_qu_ev.push(std::make_pair<EventSP, ConnectionSPC>(nullptr, con));
+      }
+      else{ //identified connection  
+	BufferSerializer ser(ev.packet.begin(), ev.packet.end());
+	uint32_t id;
+	ser.PreRead(id);
+	auto ev_con = std::make_pair<EventSP, ConnectionSPC>
+	  (Factory<Event>::MakeUnique<Deserializer&>(id, ser), con);
+	std::unique_lock<std::mutex> lk(m_mx_qu_ev);
+	m_qu_ev.push(ev_con);
+	if(m_qu_ev.size() > 50000){
+	  m_qu_ev.pop();
+	  EUDAQ_WARN("Buffer of receving event is full.");
+	}
+	lk.unlock();
+	m_cv_not_empty.notify_all();
+      }
+      break;
+    default:
+      std::cout << "Unknown:    " << *con << std::endl;
+    }
+  }
+
+  bool DataReceiver::AsyncReceiving(){
+    while (m_is_listening) {
+      m_dataserver->Process(100000);
+    }
+    return 0;
+  }
+
+  bool DataReceiver::AsyncForwarding(){
+    while(m_is_listening){
+      std::unique_lock<std::mutex> lk(m_mx_qu_ev);
+      if(m_qu_ev.empty()){
+	m_cv_not_empty.wait(lk);
+      }
+      auto ev = m_qu_ev.front().first;
+      auto con = m_qu_ev.front().second;
+      m_qu_ev.pop();
+      lk.unlock();
+      if(ev){
+	OnReceive(con, ev);
+      }
+      else{
+	if(con->GetState())
+	  OnConnect(con);
+	else
+	  OnDisconnect(con);	  
+      }
+    }
+    return 0;
+  }
+  
+  void DataReceiver::Listen(const std::string &addr){
+    std::string listen = "tcp://0";
+    if(addr.empty()){
+      listen = addr;
+    }
+
+    std::unique_lock<std::mutex> lk_deamon(m_mx_deamon);
+    m_is_listening = false;
+    try{
+      if(m_fut_async_rcv.valid()){
+	m_fut_async_rcv.get();
+      }
+      if(m_fut_async_fwd.valid()){
+	m_fut_async_fwd.get();
+      }
+    }
+    catch(...){
+      EUDAQ_WARN("connection execption from disconnetion");
+    }
+    
+    std::unique_lock<std::mutex> lk(m_mx_qu_ev);    
+    m_qu_ev = std::queue<std::pair<EventSP, ConnectionSPC>>();    
+    lk.unlock();
+
+    m_dataserver.reset(TransportServer::CreateServer(listen));
+    m_dataserver->SetCallback(TransportCallback(this, &DataReceiver::DataHandler));
+
+    m_is_listening = true;
+    m_fut_async_rcv = std::async(std::launch::async, &DataReceiver::AsyncReceiving, this); 
+    m_fut_async_fwd = std::async(std::launch::async, &DataReceiver::AsyncForwarding, this);
+  }
+
+  bool DataReceiver::Deamon(){
+    while(!m_is_destructing){
+      std::this_thread::sleep_for(std::chrono::milliseconds(200));
+      std::chrono::milliseconds t(10);
+      std::unique_lock<std::mutex> lk_deamon(m_mx_deamon);
+      try{
+	if(m_fut_async_rcv.valid()){
+	  m_fut_async_rcv.wait_for(t);
+	}
+	if(m_fut_async_fwd.valid()){
+	  m_fut_async_fwd.wait_for(t);
+	}
+      }
+      catch(...){
+	EUDAQ_WARN("connection execption from disconnetion");
+      }
+    }
+  }
+  
+}

--- a/main/lib/core/src/DataReceiver.cc
+++ b/main/lib/core/src/DataReceiver.cc
@@ -138,7 +138,7 @@ namespace eudaq {
     return 0;
   }
   
-  void DataReceiver::Listen(const std::string &addr){
+  std::string DataReceiver::Listen(const std::string &addr){
     std::string listen = "tcp://0";
     if(addr.empty()){
       listen = addr;
@@ -168,6 +168,7 @@ namespace eudaq {
     m_is_listening = true;
     m_fut_async_rcv = std::async(std::launch::async, &DataReceiver::AsyncReceiving, this); 
     m_fut_async_fwd = std::async(std::launch::async, &DataReceiver::AsyncForwarding, this);
+    return m_dataserver->ConnectionString();
   }
 
   bool DataReceiver::Deamon(){

--- a/main/lib/core/src/DataReceiver.cc
+++ b/main/lib/core/src/DataReceiver.cc
@@ -11,7 +11,6 @@ namespace eudaq {
   
   DataReceiver::DataReceiver()
     :m_is_listening(false),m_is_destructing(false), m_last_addr("tcp://0"){
-    m_fut_deamon = std::async(std::launch::async, &DataReceiver::Deamon, this); 
   }
 
   DataReceiver::~DataReceiver(){
@@ -158,6 +157,9 @@ namespace eudaq {
   }
   
   std::string DataReceiver::Listen(const std::string &addr){
+    if(!m_fut_deamon.valid())
+      m_fut_deamon = std::async(std::launch::async, &DataReceiver::Deamon, this); 
+
     std::string this_addr = m_last_addr;
     if(!addr.empty()){
       this_addr = addr;
@@ -225,7 +227,7 @@ namespace eudaq {
 	    m_dataserver.reset();
 	}
 	catch(...){
-	  EUDAQ_WARN("DataReceiver: Connection execption");
+	  EUDAQ_WARN("DataReceiver: Deamon catches an execption when closing server");
 	}
       }
     }    

--- a/main/lib/core/src/DataReceiver.cc
+++ b/main/lib/core/src/DataReceiver.cc
@@ -151,6 +151,7 @@ namespace eudaq {
       this_addr = addr;
     }
 
+    std::cout<< "DataReceiver<<<<<<<<<listen enter"<<std::endl;
     if(m_dataserver){
       EUDAQ_THROW("last server did not closed sucessfully");
     }
@@ -163,6 +164,8 @@ namespace eudaq {
     return m_last_addr;
   }
 
+  void DataReceiver::StopListen(){m_is_listening = false;} //TODO: remove this method later
+  
   bool DataReceiver::Deamon(){
     while(!m_is_destructing){
       std::this_thread::sleep_for(std::chrono::milliseconds(200));

--- a/main/lib/core/src/DataSender.cc
+++ b/main/lib/core/src/DataSender.cc
@@ -54,7 +54,7 @@ namespace eudaq {
     i0 = i1+1;
     i1 = packet.find(' ', i0);
     part = std::string(packet, i0, i1-i0);
-    if (part != "DataCollector" && part != "Monitor" )
+    if (part != "DataReceiver" && part != "DataCollector" && part != "Monitor" )
       EUDAQ_THROW("Invalid response from DataCollector server, part=" + part);
 
     m_dataclient->SendPacket("OK EUDAQ DATA " + m_type + " " + m_name);
@@ -72,7 +72,7 @@ namespace eudaq {
       EUDAQ_THROW("Transport not connected error");
     std::unique_lock<std::mutex> lk(m_mx_qu_ev);
     m_qu_ev.push(ev);
-    if(m_qu_ev.size() > 10000){
+    if(m_qu_ev.size() > 50000){
       m_qu_ev.pop();
       EUDAQ_WARN("Buffer of sending event is full.");
     }

--- a/main/lib/core/src/DataSender.cc
+++ b/main/lib/core/src/DataSender.cc
@@ -43,11 +43,11 @@ namespace eudaq {
     if (std::string(packet, 0, i1) != "OK") EUDAQ_THROW("Connection refused by DataCollector server: " + packet);
   }
 
-  void DataSender::SendEvent(const Event &ev) {
+  void DataSender::SendEvent(EventSPC ev) {
     if (!m_dataclient) EUDAQ_THROW("Transport not connected error");
     //EUDAQ_DEBUG("Serializing event");
     BufferSerializer ser;
-    ev.Serialize(ser);
+    ev->Serialize(ser);
     //EUDAQ_DEBUG("Sending event");
     m_packetCounter += 1;
     m_dataclient->SendPacket(ser);

--- a/main/lib/core/src/DataSender.cc
+++ b/main/lib/core/src/DataSender.cc
@@ -87,7 +87,6 @@ namespace eudaq {
       m_qu_ev.pop();
       EUDAQ_WARN("DataSender:: Buffer of sending event is full.");
     }
-    lk.unlock();
     m_cv_not_empty.notify_all();
   }
 
@@ -108,9 +107,8 @@ namespace eudaq {
       BufferSerializer ser;
       ev->Serialize(ser);
       m_packetCounter += 1;
-      std::cout<<">>>>>>>>>>>>>>>>>>>>>m_dataclient->SendPacket(ser)...."<<std::endl;
+      //TODO: catch exception below
       m_dataclient->SendPacket(ser);
-      std::cout<<">>>>>>>>>>>>>>>>>>>>>m_dataclient->SendPacket(ser)"<<std::endl;
     }
     
   }

--- a/main/lib/core/src/DataSender.cc
+++ b/main/lib/core/src/DataSender.cc
@@ -12,7 +12,28 @@ namespace eudaq {
     m_name(name),
     m_packetCounter(0) {}
 
+
+  DataSender::~DataSender(){
+    if(m_fut_async.valid()){
+      m_fut_async.get();
+    }
+  }
+  
   void DataSender::Connect(const std::string & server) {
+    m_is_connected = false;
+    try{
+      if(m_fut_async.valid()){
+	m_fut_async.get();
+	//previous connection is closed.
+      }
+    }
+    catch(...){
+      EUDAQ_WARN("connection execption from disconnetion");
+    }
+    
+    std::unique_lock<std::mutex> lk(m_mx_qu_ev);    
+    m_qu_ev = std::queue<EventSPC>();    
+    lk.unlock();
     m_dataclient.reset(TransportClient::CreateClient(server));
     std::string packet;
     if (!m_dataclient->ReceivePacket(&packet, 1000000)) EUDAQ_THROW("No response from DataCollector server");
@@ -41,17 +62,38 @@ namespace eudaq {
     if (!m_dataclient->ReceivePacket(&packet, 1000000)) EUDAQ_THROW("No response from DataCollector server");
     i1 = packet.find(' ');
     if (std::string(packet, 0, i1) != "OK") EUDAQ_THROW("Connection refused by DataCollector server: " + packet);
+
+    m_is_connected = true;
+    m_fut_async = std::async(std::launch::async, &DataSender::AsyncSending, this);
   }
 
-  void DataSender::SendEvent(EventSPC ev) {
-    if (!m_dataclient) EUDAQ_THROW("Transport not connected error");
-    //EUDAQ_DEBUG("Serializing event");
-    BufferSerializer ser;
-    ev->Serialize(ser);
-    //EUDAQ_DEBUG("Sending event");
-    m_packetCounter += 1;
-    m_dataclient->SendPacket(ser);
-    //EUDAQ_DEBUG("Sent event");
+  void DataSender::SendEvent(EventSPC ev){
+    if (!m_dataclient)
+      EUDAQ_THROW("Transport not connected error");
+    std::unique_lock<std::mutex> lk(m_mx_qu_ev);
+    m_qu_ev.push(ev);
+    if(m_qu_ev.size() > 10000){
+      m_qu_ev.pop();
+      EUDAQ_WARN("Buffer of sending event is full.");
+    }
+    lk.unlock();
+    m_cv_not_empty.notify_all();
   }
 
+  bool DataSender::AsyncSending(){
+    while(m_is_connected){//TODO: 
+      std::unique_lock<std::mutex> lk(m_mx_qu_ev);
+      if(m_qu_ev.empty()){
+	m_cv_not_empty.wait(lk);
+      }
+      auto ev = m_qu_ev.front();
+      m_qu_ev.pop();
+      lk.unlock();
+      BufferSerializer ser;
+      ev->Serialize(ser);
+      m_packetCounter += 1;
+      m_dataclient->SendPacket(ser);
+    }
+  }
+  
 }

--- a/main/lib/core/src/LogCollector.cc
+++ b/main/lib/core/src/LogCollector.cc
@@ -152,4 +152,12 @@ namespace eudaq {
       std::this_thread::sleep_for(std::chrono::milliseconds(500));
     }
   }
+  
+  LogCollectorSP LogCollector::Make(const std::string &code_name,
+				    const std::string &run_name,
+				    const std::string &runcontrol){
+    return Factory<LogCollector>::
+      MakeShared<const std::string&,const std::string&>
+      (eudaq::str2hash(code_name), run_name, runcontrol);
+  }
 }

--- a/main/lib/core/src/LogCollector.cc
+++ b/main/lib/core/src/LogCollector.cc
@@ -27,7 +27,7 @@ namespace eudaq {
     auto conf = GetConfiguration();
     try{
       DoInitialise();
-      SetStatus(Status::STATE_UNCONF, "Initialized");
+      CommandReceiver::OnInitialise();
     }catch (const Exception &e) {
       std::string msg = "Error when init by " + conf->Name() + ": " + e.what();
       EUDAQ_ERROR(msg);
@@ -39,7 +39,7 @@ namespace eudaq {
   void LogCollector::OnTerminate(){
     CloseLogCollector();
     DoTerminate();
-    SetStatus(Status::STATE_UNINIT, "Terminated");
+    CommandReceiver::OnTerminate();
     std::exit(0);
   }
   
@@ -147,9 +147,9 @@ namespace eudaq {
   
   void LogCollector::Exec(){
     StartLogCollector(); //TODO: Start it OnServer
-    // StartCommandReceiver();
-    // while(IsActiveCommandReceiver() || IsActiveLogCollector()){
-    //   std::this_thread::sleep_for(std::chrono::milliseconds(500));
-    // }
+    StartCommandReceiver();
+    while(IsActiveCommandReceiver() || IsActiveLogCollector()){
+      std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    }
   }
 }

--- a/main/lib/core/src/LogCollector.cc
+++ b/main/lib/core/src/LogCollector.cc
@@ -147,9 +147,9 @@ namespace eudaq {
   
   void LogCollector::Exec(){
     StartLogCollector(); //TODO: Start it OnServer
-    StartCommandReceiver();
-    while(IsActiveCommandReceiver() || IsActiveLogCollector()){
-      std::this_thread::sleep_for(std::chrono::milliseconds(500));
-    }
+    // StartCommandReceiver();
+    // while(IsActiveCommandReceiver() || IsActiveLogCollector()){
+    //   std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    // }
   }
 }

--- a/main/lib/core/src/LogCollector.cc
+++ b/main/lib/core/src/LogCollector.cc
@@ -147,8 +147,8 @@ namespace eudaq {
   
   void LogCollector::Exec(){
     StartLogCollector(); //TODO: Start it OnServer
-    StartCommandReceiver();
-    while(IsActiveCommandReceiver() || IsActiveLogCollector()){
+    Connect();
+    while(IsConnected() || IsActiveLogCollector()){
       std::this_thread::sleep_for(std::chrono::milliseconds(500));
     }
   }

--- a/main/lib/core/src/LogCollector.cc
+++ b/main/lib/core/src/LogCollector.cc
@@ -128,12 +128,14 @@ namespace eudaq {
     if(m_exit){
       EUDAQ_THROW("LogCollector can not be restarted after exit. (TODO)");
     }
+    if(m_log_addr.empty()){
+      m_log_addr = "tcp://0";
+    }
     m_logserver.reset(TransportServer::CreateServer(m_log_addr)),
     m_logserver->SetCallback(TransportCallback(this, &LogCollector::LogHandler));
     
     m_thd_server = std::thread(&LogCollector::LogThread, this);
-    std::cout << "###### listenaddress=" << m_logserver->ConnectionString()
-              << std::endl;
+    m_log_addr = m_logserver->ConnectionString();
     SetStatusTag("_SERVER", m_log_addr);
   }
 

--- a/main/lib/core/src/Monitor.cc
+++ b/main/lib/core/src/Monitor.cc
@@ -15,8 +15,7 @@ namespace eudaq {
   Factory<Monitor>::Instance<const std::string&, const std::string&>(); //TODO
   
   Monitor::Monitor(const std::string &name, const std::string &runcontrol)
-    :CommandReceiver("Monitor", name, runcontrol){  
-    m_exit = false;
+    :CommandReceiver("Monitor", name, runcontrol){
   }
   
   void Monitor::OnInitialise(){
@@ -27,8 +26,7 @@ namespace eudaq {
       SetStatusTag("_SERVER", m_data_addr);
       StopListen();
       DoInitialise();
-      SetStatus(Status::STATE_UNCONF, "Initialized");
-      EUDAQ_INFO(GetFullName() + " is initialised.");
+      CommandReceiver::OnInitialise();
     }catch (const Exception &e) {
       std::string msg = "Error when init by " + conf->Name() + ": " + e.what();
       EUDAQ_ERROR(msg);
@@ -42,8 +40,7 @@ namespace eudaq {
     try {
       SetStatus(Status::STATE_UNCONF, "Configuring");
       DoConfigure();
-      SetStatus(Status::STATE_CONF, "Configured");
-      EUDAQ_INFO(GetFullName() + " is configured.");
+      CommandReceiver::OnConfigure();
     }catch (const Exception &e) {
       std::string msg = "Error when configuring by " + conf->Name() + ": " + e.what();
       EUDAQ_ERROR(msg);
@@ -57,8 +54,7 @@ namespace eudaq {
       m_data_addr = Listen(m_data_addr);
       SetStatusTag("_SERVER", m_data_addr);
       DoStartRun();
-      SetStatus(Status::STATE_RUNNING, "Started");
-      EUDAQ_INFO("RUN #" + std::to_string(GetRunNumber()) + " is started.");
+      CommandReceiver::OnStartRun();
     } catch (const Exception &e) {
       std::string msg = "Error preparing for run " + std::to_string(GetRunNumber()) + ": " + e.what();
       EUDAQ_ERROR(msg);
@@ -70,8 +66,7 @@ namespace eudaq {
     EUDAQ_INFO("RUN #" + std::to_string(GetRunNumber()) + " is to be stopped...");
     try {
       DoStopRun();
-      SetStatus(Status::STATE_CONF, "Stopped");
-      EUDAQ_INFO("RUN #" + std::to_string(GetRunNumber()) + " is stopped.");
+      CommandReceiver::OnStopRun();
     } catch (const Exception &e) {
       std::string msg = "Error stopping for run " + std::to_string(GetRunNumber()) + ": " + e.what();
       EUDAQ_ERROR(msg);
@@ -83,8 +78,7 @@ namespace eudaq {
     EUDAQ_INFO(GetFullName() + " is to be reset...");
     try{
       DoReset();
-      SetStatus(Status::STATE_UNINIT, "Reset");
-      EUDAQ_INFO(GetFullName() + " is reset.");
+      CommandReceiver::OnReset();
     } catch (const std::exception &e) {
       printf("Producer Reset:: Caught exception: %s\n", e.what());
       SetStatus(Status::STATE_ERROR, "Reset Error");
@@ -96,120 +90,19 @@ namespace eudaq {
   
   void Monitor::OnTerminate(){
     EUDAQ_INFO(GetFullName() + " is to be terminated...");
-    CloseMonitor();
     DoTerminate();
-    SetStatus(Status::STATE_UNINIT, "Terminated");
-    EUDAQ_INFO(GetFullName() + " is terminated.");
+    CommandReceiver::OnTerminate();
   }
     
   void Monitor::OnStatus(){
     // SetStatusTag("EventN", std::to_string(m_evt_c));
     DoStatus();
   }
-  
-  void Monitor::DataHandler(TransportEvent &ev) {
-    auto con = ev.id;
-    switch (ev.etype) {
-    case (TransportEvent::CONNECT):
-      m_dataserver->SendPacket("OK EUDAQ DATA Monitor", *con, true);
-      break;
-    case (TransportEvent::DISCONNECT):
-      EUDAQ_INFO("Disconnected: " + to_string(*con));
-      break;
-    case (TransportEvent::RECEIVE):
-      if (con->GetState() == 0) { // waiting for identification
-        do {
-          size_t i0 = 0, i1 = ev.packet.find(' ');
-          if (i1 == std::string::npos)
-            break;
-          std::string part(ev.packet, i0, i1);
-          if (part != "OK")
-            break;
-          i0 = i1 + 1;
-          i1 = ev.packet.find(' ', i0);
-          if (i1 == std::string::npos)
-            break;
-          part = std::string(ev.packet, i0, i1 - i0);
-          if (part != "EUDAQ")
-            break;
-          i0 = i1 + 1;
-          i1 = ev.packet.find(' ', i0);
-          if (i1 == std::string::npos)
-            break;
-          part = std::string(ev.packet, i0, i1 - i0);
-          if (part != "DATA")
-            break;
-          i0 = i1 + 1;
-          i1 = ev.packet.find(' ', i0);
-          part = std::string(ev.packet, i0, i1 - i0);
-          con->SetType(part);
-          i0 = i1 + 1;
-          i1 = ev.packet.find(' ', i0);
-          part = std::string(ev.packet, i0, i1 - i0);
-          con->SetName(part);
-        } while (false);
-        m_dataserver->SendPacket("OK", *con, true);
-        con->SetState(1); // successfully identified
-	EUDAQ_INFO("Connection from " + to_string(*con));
-      } else{
-        BufferSerializer ser(ev.packet.begin(), ev.packet.end());
-	uint32_t id;
-	ser.PreRead(id);
-	EventUP event = Factory<Event>::MakeUnique<Deserializer&>(id, ser);
-	SetStatusTag("EventN", std::to_string(event->GetEventN()));
-	DoReceive(std::move(event));
-      }
-      break;
-    default:
-      std::cout << "Unknown:    " << *con << std::endl;
-    }
+
+  void Monitor::OnReceive(ConnectionSPC id, EventSP ev){
+    DoReceive(ev);
   }
   
-  void Monitor::DataThread() {
-    try {
-      while (!m_exit) {
-        m_dataserver->Process(100000);
-      }
-    } catch (const std::exception &e) {
-      std::cout << "Error: Uncaught exception: " << e.what() << "\n"
-                << "DataThread is dying..." << std::endl;
-      m_exit = true;
-    } catch (...) {
-      std::cout << "Error: Uncaught unrecognised exception: \n"
-                << "DataThread is dying..." << std::endl;
-      m_exit = true;
-    }
-  }
-
-  void Monitor::StartMonitor(){
-    if(m_exit){
-      EUDAQ_THROW("Monitor can not be restarted after exit. (TODO)");
-    }
-    if(m_data_addr.empty()){
-      m_data_addr = "tcp://0";
-    }
-    m_dataserver.reset(TransportServer::CreateServer(m_data_addr));
-    m_dataserver->SetCallback(TransportCallback(this, &Monitor::DataHandler));
-    m_thd_server = std::thread(&Monitor::DataThread, this);
-    m_data_addr = m_dataserver->ConnectionString();
-    SetStatusTag("_SERVER", m_data_addr);
-  }
-
-  void Monitor::CloseMonitor(){
-    m_exit = true;
-    if(m_thd_server.joinable()){
-      m_thd_server.join();
-    } 
-  }
-  
-  void Monitor::Exec(){
-    StartMonitor();
-    // StartCommandReceiver();
-    // while(IsActiveCommandReceiver() || IsActiveMonitor()){
-    //   std::this_thread::sleep_for(std::chrono::milliseconds(500));
-    // }
-  }
-
   MonitorSP Monitor::Make(const std::string &code_name,
 			  const std::string &run_name,
 			  const std::string &runcontrol){

--- a/main/lib/core/src/Monitor.cc
+++ b/main/lib/core/src/Monitor.cc
@@ -23,6 +23,9 @@ namespace eudaq {
     EUDAQ_INFO(GetFullName() + " is to be initialised...");
     auto conf = GetConfiguration();
     try{
+      m_data_addr = Listen(m_data_addr);
+      SetStatusTag("_SERVER", m_data_addr);
+      StopListen();
       DoInitialise();
       SetStatus(Status::STATE_UNCONF, "Initialized");
       EUDAQ_INFO(GetFullName() + " is initialised.");
@@ -51,9 +54,8 @@ namespace eudaq {
   void Monitor::OnStartRun(){
     EUDAQ_INFO("RUN #" + std::to_string(GetRunNumber()) + " is to be started...");
     try {
-      if (!m_dataserver) {
-        EUDAQ_THROW("You must configure before starting a run");
-      }
+      m_data_addr = Listen(m_data_addr);
+      SetStatusTag("_SERVER", m_data_addr);
       DoStartRun();
       SetStatus(Status::STATE_RUNNING, "Started");
       EUDAQ_INFO("RUN #" + std::to_string(GetRunNumber()) + " is started.");
@@ -202,10 +204,10 @@ namespace eudaq {
   
   void Monitor::Exec(){
     StartMonitor();
-    StartCommandReceiver();
-    while(IsActiveCommandReceiver() || IsActiveMonitor()){
-      std::this_thread::sleep_for(std::chrono::milliseconds(500));
-    }
+    // StartCommandReceiver();
+    // while(IsActiveCommandReceiver() || IsActiveMonitor()){
+    //   std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    // }
   }
 
   MonitorSP Monitor::Make(const std::string &code_name,

--- a/main/lib/core/src/Monitor.cc
+++ b/main/lib/core/src/Monitor.cc
@@ -17,6 +17,34 @@ namespace eudaq {
   Monitor::Monitor(const std::string &name, const std::string &runcontrol)
     :CommandReceiver("Monitor", name, runcontrol){
   }
+
+  void Monitor::DoInitialise(){
+  }
+
+  void Monitor::DoConfigure(){
+  }
+
+  void Monitor::DoStartRun(){
+  }
+
+  void Monitor::DoStopRun(){
+  }
+
+  void Monitor::DoReset(){
+  }
+
+  void Monitor::DoTerminate(){
+  }
+
+  void Monitor::DoStatus(){
+  }
+
+  void Monitor::DoReceive(EventSP ev){
+  }
+    
+  void Monitor::SetServerAddress(const std::string &addr){
+    m_data_addr = addr;
+  }
   
   void Monitor::OnInitialise(){
     EUDAQ_INFO(GetFullName() + " is to be initialised...");
@@ -66,6 +94,7 @@ namespace eudaq {
     EUDAQ_INFO("RUN #" + std::to_string(GetRunNumber()) + " is to be stopped...");
     try {
       DoStopRun();
+      StopListen();
       CommandReceiver::OnStopRun();
     } catch (const Exception &e) {
       std::string msg = "Error stopping for run " + std::to_string(GetRunNumber()) + ": " + e.what();
@@ -78,6 +107,7 @@ namespace eudaq {
     EUDAQ_INFO(GetFullName() + " is to be reset...");
     try{
       DoReset();
+      StopListen();
       CommandReceiver::OnReset();
     } catch (const std::exception &e) {
       printf("Producer Reset:: Caught exception: %s\n", e.what());

--- a/main/lib/core/src/Monitor.cc
+++ b/main/lib/core/src/Monitor.cc
@@ -102,6 +102,7 @@ namespace eudaq {
     
   void Monitor::OnStatus(){
     // SetStatusTag("EventN", std::to_string(m_evt_c));
+    DoStatus();
   }
   
   void Monitor::DataHandler(TransportEvent &ev) {

--- a/main/lib/core/src/Monitor.cc
+++ b/main/lib/core/src/Monitor.cc
@@ -184,13 +184,12 @@ namespace eudaq {
       EUDAQ_THROW("Monitor can not be restarted after exit. (TODO)");
     }
     if(m_data_addr.empty()){
-      m_data_addr = "tcp://";
-      uint16_t port = static_cast<uint16_t>(GetCommandReceiverID()) + 1024;
-      m_data_addr += to_string(port);
+      m_data_addr = "tcp://0";
     }
     m_dataserver.reset(TransportServer::CreateServer(m_data_addr));
     m_dataserver->SetCallback(TransportCallback(this, &Monitor::DataHandler));
     m_thd_server = std::thread(&Monitor::DataThread, this);
+    m_data_addr = m_dataserver->ConnectionString();
     SetStatusTag("_SERVER", m_data_addr);
   }
 

--- a/main/lib/core/src/Monitor.cc
+++ b/main/lib/core/src/Monitor.cc
@@ -15,7 +15,7 @@ namespace eudaq {
   Factory<Monitor>::Instance<const std::string&, const std::string&>(); //TODO
   
   Monitor::Monitor(const std::string &name, const std::string &runcontrol)
-    :CommandReceiver("Monitor", name, runcontrol){
+    :m_evt_c(0),CommandReceiver("Monitor", name, runcontrol){
   }
 
   void Monitor::DoInitialise(){
@@ -53,6 +53,7 @@ namespace eudaq {
       m_data_addr = Listen(m_data_addr);
       SetStatusTag("_SERVER", m_data_addr);
       StopListen();
+      SendStatus();
       DoInitialise();
       CommandReceiver::OnInitialise();
     }catch (const Exception &e) {
@@ -81,6 +82,7 @@ namespace eudaq {
     try {
       m_data_addr = Listen(m_data_addr);
       SetStatusTag("_SERVER", m_data_addr);
+      m_evt_c = 0;
       DoStartRun();
       CommandReceiver::OnStartRun();
     } catch (const Exception &e) {
@@ -125,11 +127,13 @@ namespace eudaq {
   }
     
   void Monitor::OnStatus(){
-    // SetStatusTag("EventN", std::to_string(m_evt_c));
+    SetStatusTag("EventN", std::to_string(m_evt_c));
     DoStatus();
+    CommandReceiver::OnStatus();
   }
 
   void Monitor::OnReceive(ConnectionSPC id, EventSP ev){
+    m_evt_c ++;
     DoReceive(ev);
   }
   

--- a/main/lib/core/src/Monitor.cc
+++ b/main/lib/core/src/Monitor.cc
@@ -207,4 +207,13 @@ namespace eudaq {
       std::this_thread::sleep_for(std::chrono::milliseconds(500));
     }
   }
+
+  MonitorSP Monitor::Make(const std::string &code_name,
+			  const std::string &run_name,
+			  const std::string &runcontrol){
+    return Factory<Monitor>::
+      MakeShared<const std::string&,const std::string&>
+      (eudaq::str2hash(code_name), run_name, runcontrol);
+  }
+
 }

--- a/main/lib/core/src/Producer.cc
+++ b/main/lib/core/src/Producer.cc
@@ -139,6 +139,19 @@ namespace eudaq {
       SetStatus(Status::STATE_ERROR, "Terminate Error");
     }
   }
+
+  void Producer::OnStatus(){
+    try{
+      SetStatusTag("EventN", std::to_string(m_evt_c));
+      DoStatus();
+    }catch (const std::exception &e) {
+      printf("Caught exception: %s\n", e.what());
+      SetStatus(Status::STATE_ERROR, "Status Error");
+    } catch (...) {
+      printf("Unknown exception\n");
+      SetStatus(Status::STATE_ERROR, "Status Error");
+    }
+  }
   
   void Producer::Exec(){
     StartCommandReceiver();
@@ -160,13 +173,12 @@ namespace eudaq {
     ev->SetDeviceN(m_pdc_n);
     for(auto &e: m_senders){
       if(e.second)
-	e.second->SendEvent(*(ev.get()));
+	e.second->SendEvent(ev);
       else
 	EUDAQ_THROW("Producer::SendEvent, using a null pointer of DataSender");
     }
-    SetStatusTag("EventN", std::to_string(m_evt_c));
   }
-
+  
   ProducerSP Producer::Make(const std::string &code_name,
 			    const std::string &run_name,
 			    const std::string &runcontrol){

--- a/main/lib/core/src/Producer.cc
+++ b/main/lib/core/src/Producer.cc
@@ -166,4 +166,13 @@ namespace eudaq {
     }
     SetStatusTag("EventN", std::to_string(m_evt_c));
   }
+
+  ProducerSP Producer::Make(const std::string &code_name,
+			    const std::string &run_name,
+			    const std::string &runcontrol){
+    return Factory<Producer>::
+      MakeShared<const std::string&,const std::string&>
+      (eudaq::str2hash(code_name), run_name, runcontrol);
+  }
 }
+

--- a/main/lib/core/src/Producer.cc
+++ b/main/lib/core/src/Producer.cc
@@ -66,17 +66,17 @@ namespace eudaq {
       m_evt_c = 0;
       std::string dc_str = GetConfiguration()->Get("EUDAQ_DC", "");
       std::vector<std::string> col_dc_name = split(dc_str, ";,", true);
-      std::string cur_backup = GetInitConfiguration()->GetCurrentSectionName();
-      GetInitConfiguration()->SetSection("");//NOTE: it is m_conf_init
+      std::string cur_backup = GetConfiguration()->GetCurrentSectionName();
+      GetConfiguration()->SetSection("");
       for(auto &dc_name: col_dc_name){
-	std::string dc_addr =  GetInitConfiguration()->Get("DataCollector."+dc_name, "");
+	std::string dc_addr =  GetConfiguration()->Get("DataCollector."+dc_name, "");
 	if(!dc_addr.empty()){
 	  m_senders[dc_addr]
 	    = std::unique_ptr<DataSender>(new DataSender("Producer", GetName()));
 	  m_senders[dc_addr]->Connect(dc_addr);
 	}
       }
-      GetInitConfiguration()->SetSection(cur_backup);
+      GetConfiguration()->SetSection(cur_backup);
       SetStatusTag("EventN", std::to_string(m_evt_c));      
       DoStartRun();
       SetStatus(Status::STATE_RUNNING, "Started");
@@ -154,10 +154,10 @@ namespace eudaq {
   }
   
   void Producer::Exec(){
-    StartCommandReceiver();
-    while(IsActiveCommandReceiver()){
-      std::this_thread::sleep_for(std::chrono::milliseconds(500));
-    }
+    // StartCommandReceiver();
+    // while(IsActiveCommandReceiver()){
+    //   std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    // }
   }
 
   void Producer::SendEvent(EventSP ev){

--- a/main/lib/core/src/Producer.cc
+++ b/main/lib/core/src/Producer.cc
@@ -24,8 +24,7 @@ namespace eudaq {
 	EUDAQ_THROW("No Configuration Section for OnInitialise");
       EUDAQ_INFO("Initializing ...(" + conf->Name() + ")");
       DoInitialise();
-      SetStatus(Status::STATE_UNCONF, "Initialized");
-      EUDAQ_INFO(GetFullName() + " is initialised.");
+      CommandReceiver::OnInitialise();
     }catch (const std::exception &e) {
       printf("Caught exception: %s\n", e.what());
       SetStatus(Status::STATE_ERROR, "Init Error");
@@ -46,8 +45,7 @@ namespace eudaq {
 	EUDAQ_THROW("No Configuration Section for OnConfigure");
       m_pdc_n = conf->Get("EUDAQ_ID", m_pdc_n);
       DoConfigure();
-      SetStatus(Status::STATE_CONF, "Configured");
-      EUDAQ_INFO(GetFullName() + " is configured.");
+      CommandReceiver::OnConfigure();
     }catch (const std::exception &e) {
       printf("Caught exception: %s\n", e.what());
       SetStatus(Status::STATE_ERROR, "Configuration Error");
@@ -77,10 +75,9 @@ namespace eudaq {
 	}
       }
       GetConfiguration()->SetSection(cur_backup);
-      SetStatusTag("EventN", std::to_string(m_evt_c));      
+      SetStatusTag("EventN", "0");
       DoStartRun();
-      SetStatus(Status::STATE_RUNNING, "Started");
-      EUDAQ_INFO("RUN #" + std::to_string(GetRunNumber()) + " is started.");
+      CommandReceiver::OnStartRun();
     }catch (const std::exception &e) {
       printf("Caught exception: %s\n", e.what());
       SetStatus(Status::STATE_ERROR, "Start Error");
@@ -98,8 +95,7 @@ namespace eudaq {
       EUDAQ_INFO("Stopping Run");
       DoStopRun();
       m_senders.clear();
-      SetStatus(Status::STATE_CONF, "Stopped");
-      EUDAQ_INFO("RUN #" + std::to_string(GetRunNumber()) + " is stopped.");
+      CommandReceiver::OnStopRun();
     } catch (const std::exception &e) {
       printf("Caught exception: %s\n", e.what());
       SetStatus(Status::STATE_ERROR, "Stop Error");
@@ -114,12 +110,11 @@ namespace eudaq {
     try{
       DoReset();
       m_senders.clear();
-      SetStatus(Status::STATE_UNINIT, "Reset");
-      EUDAQ_INFO(GetFullName() + " is reset.");
+      CommandReceiver::OnReset();
     } catch (const std::exception &e) {
       printf("Producer Reset:: Caught exception: %s\n", e.what());
       SetStatus(Status::STATE_ERROR, "Reset Error");
-    } catch (...) {
+    } catch (...){
       printf("Producer Reset:: Unknown exception\n");
       SetStatus(Status::STATE_ERROR, "Reset Error");
     }
@@ -129,8 +124,7 @@ namespace eudaq {
     EUDAQ_INFO(GetFullName() + " is to be terminated...");
     try{
       DoTerminate();
-      SetStatus(Status::STATE_UNINIT, "Terminated");
-      EUDAQ_INFO(GetFullName() + " is terminated.");
+      CommandReceiver::OnTerminate();
     }catch (const std::exception &e) {
       printf("Caught exception: %s\n", e.what());
       SetStatus(Status::STATE_ERROR, "Terminate Error");
@@ -153,13 +147,6 @@ namespace eudaq {
     }
   }
   
-  void Producer::Exec(){
-    // StartCommandReceiver();
-    // while(IsActiveCommandReceiver()){
-    //   std::this_thread::sleep_for(std::chrono::milliseconds(500));
-    // }
-  }
-
   void Producer::SendEvent(EventSP ev){
     if(ev->IsBORE()){
       if(GetConfiguration())

--- a/main/lib/core/src/RunControl.cc
+++ b/main/lib/core/src/RunControl.cc
@@ -70,9 +70,10 @@ namespace eudaq {
 	    + server_addr.substr(server_addr.find_last_not_of("0123456789")+1);
 	}
 	std::string server_name = conn_type+"."+conn_name;
-	if(server_name=="LogCollector.log"){
-	  if(!server_addr.empty())
-	    SendCommand("LOG", server_addr);
+	if(server_name=="LogCollector.log" && !server_addr.empty()){
+	  m_conf_init->SetSection("");
+	  m_conf_init->SetString("EUDAQ_LOG_ADDR", server_addr);
+	  SendCommand("LOG", server_addr);
 	}
       }
     }
@@ -100,7 +101,6 @@ namespace eudaq {
     m_listening = false;
 
     m_conf->SetSection("");
-    std::string log_addr;
     for(auto &conn: conn_to_conf){
       std::string conn_type = conn->GetType();
       std::string conn_name = conn->GetName();
@@ -116,8 +116,6 @@ namespace eudaq {
 	}
 	std::string server_name = conn_type+"."+conn_name;
 	m_conf->SetString(server_name, server_addr);
-	if(server_name=="LogCollector.log")
-	  log_addr=server_addr;
       }
     }
     m_conf->SetSection("RunControl"); //TODO: RunControl section must exist

--- a/main/lib/core/src/RunControl.cc
+++ b/main/lib/core/src/RunControl.cc
@@ -39,7 +39,7 @@ namespace eudaq {
   }
 
   void RunControl::Initialise(){
-    EUDAQ_INFO("Processing Configure command");
+    EUDAQ_INFO("Processing Initialise command");
     std::vector<ConnectionSPC> conn_to_init; 
     std::unique_lock<std::mutex> lk(m_mtx_conn);
     for(auto &conn_st: m_conn_status){
@@ -56,13 +56,11 @@ namespace eudaq {
     }
     lk.unlock();
 
-    m_conf_init->SetSection("");
-    std::string log_addr;
     for(auto &conn: conn_to_init){
       std::string conn_type = conn->GetType();
       std::string conn_name = conn->GetName();
       std::string conn_addr = conn->GetRemote();
-      if(conn_type == "DataCollector" || conn_type == "LogCollector" || conn_type == "Monitor"){
+      if(conn_type == "LogCollector"){
 	lk.lock();
 	std::string server_addr = m_conn_status[conn]->GetTag("_SERVER");
 	lk.unlock();
@@ -72,13 +70,12 @@ namespace eudaq {
 	    + server_addr.substr(server_addr.find_last_not_of("0123456789")+1);
 	}
 	std::string server_name = conn_type+"."+conn_name;
-	m_conf_init->SetString(server_name, server_addr);
-	if(server_name=="LogCollector.log")
-	  log_addr=server_addr;
+	if(server_name=="LogCollector.log"){
+	  if(!server_addr.empty())
+	    SendCommand("LOG", server_addr);
+	}
       }
     }
-    if(!log_addr.empty())
-      SendCommand("LOG", log_addr);
     m_conf_init->SetSection("RunControl"); //TODO: RunControl section must exist
     for(auto &conn: conn_to_init)
       SendCommand("INIT", to_string(*m_conf_init), conn);
@@ -102,6 +99,28 @@ namespace eudaq {
     lk.unlock();
     m_listening = false;
 
+    m_conf->SetSection("");
+    std::string log_addr;
+    for(auto &conn: conn_to_conf){
+      std::string conn_type = conn->GetType();
+      std::string conn_name = conn->GetName();
+      std::string conn_addr = conn->GetRemote();
+      if(conn_type == "DataCollector" || conn_type == "LogCollector" || conn_type == "Monitor"){
+	lk.lock();
+	std::string server_addr = m_conn_status[conn]->GetTag("_SERVER");
+	lk.unlock();
+	if(server_addr.find("tcp://") == 0 && conn_addr.find("tcp://") == 0){
+	  server_addr = conn_addr.substr(0, conn_addr.find_last_not_of("0123456789"))
+	    + ":"
+	    + server_addr.substr(server_addr.find_last_not_of("0123456789")+1);
+	}
+	std::string server_name = conn_type+"."+conn_name;
+	m_conf->SetString(server_name, server_addr);
+	if(server_name=="LogCollector.log")
+	  log_addr=server_addr;
+      }
+    }
+    m_conf->SetSection("RunControl"); //TODO: RunControl section must exist
     for(auto &conn: conn_to_conf)
       SendCommand("CONFIG", to_string(*m_conf), conn);
   }

--- a/main/lib/core/src/Status.cc
+++ b/main/lib/core/src/Status.cc
@@ -5,6 +5,10 @@
 
 namespace eudaq {
 
+  Status::Status(int level, const std::string &msg )
+    :m_level(level), m_state(STATE_UNINIT), m_msg(msg){
+  }
+  
   Status::Status(Deserializer &ds) {
     ds.read(m_level);
     ds.read(m_state);
@@ -12,6 +16,10 @@ namespace eudaq {
     ds.read(m_tags);
   }
 
+  Status::~Status(){
+
+  }
+  
   void Status::Serialize(Serializer &ser) const {
     ser.write(m_level);
     ser.write(m_state);
@@ -47,9 +55,28 @@ namespace eudaq {
     EUDAQ_THROW("Unrecognised level: " + str);
   }
 
-  Status &Status::SetTag(const std::string &name, const std::string &val){
+  void Status::SetMessage(const std::string &msg){
+    m_msg = msg;
+  }
+
+  std::string Status::GetMessage() const{
+    return m_msg;
+  }
+
+  int Status::GetLevel() const{
+    return m_level;
+  }
+  
+  int Status::GetState() const {
+    return m_state;
+  }
+
+  std::map<std::string, std::string> Status::GetTags() const{
+    return m_tags;
+  }
+
+  void Status::SetTag(const std::string &name, const std::string &val){
     m_tags[name] = val;
-    return *this;
   }
 
   std::string Status::GetTag(const std::string &name,

--- a/main/lib/core/src/TransportTCP.cc
+++ b/main/lib/core/src/TransportTCP.cc
@@ -17,9 +17,6 @@ broken due to keep-alive activity detecting a failure while one or more
 operations are in progress. Operations that were in progress fail with
 WSAENETRESET. Subsequent operations fail with WSAECONNRESET.
 
-
-
-
 II:
 at some places we have constructions like:
  if (m_srvsock == (SOCKET)-1)
@@ -33,11 +30,11 @@ at some places we have constructions like:
 
 
  like for example in this line:
-        SOCKET result = select(static_cast<int>(m_sock+1), &tempset, NULL, NULL,
-&timeremain);
+ SOCKET result = select(static_cast<int>(m_sock+1), &tempset, NULL, NULL,
+ &timeremain);
 
  since we have defined SOCKET on Linux to be int it will work as an int but is
-is it from the context correct?
+ is it from the context correct?
  if not we should make it to int.
 
 */
@@ -53,100 +50,8 @@ is it from the context correct?
 #if EUDAQ_PLATFORM_IS(WIN32) || EUDAQ_PLATFORM_IS(MINGW)
 #include "TransportTCP_WIN32.hh"
 #pragma comment(lib, "Ws2_32.lib")
-
-// defining error code more informations under
-// http://msdn.microsoft.com/en-us/library/windows/desktop/ms740668%28v=vs.85%29.aspx
-
-// qute:
-// "Resource temporarily unavailable.
-//
-// 	This error is returned from operations on nonblocking sockets that
-//  cannot be completed immediately, for example recv when no data is queued
-//  to be read from the socket. It is a nonfatal error, and the operation
-//  should be retried later. It is normal for WSAEWOULDBLOCK to be reported
-//  as the result from calling connect on a nonblocking SOCK_STREAM socket,
-//  since some time must elapse for the connection to be established."
-#define EUDAQ_ERROR_Resource_temp_unavailable WSAEWOULDBLOCK
-
-// qute:
-// Operation now in progress.
-//
-// 	A blocking operation is currently executing. Windows Sockets
-// 	only allows a single blocking operation (per- task or thread) to
-// 	be outstanding, and if any other function call is made (whether
-// 	or not it references that or any other socket) the function fails
-// 	with the WSAEINPROGRESS error.
-//
-#define EUDAQ_ERROR_Operation_progress WSAEINPROGRESS
-
-// Interrupted function call.
-//	A blocking operation was interrupted by a call to WSACancelBlockingCall.
-//
-#define EUDAQ_ERROR_Interrupted_function_call WSAEINTR
-
-#define EUDAQ_ERROR_NO_DATA_RECEIVED -1
 #else
-
 #include "TransportTCP_POSIX.hh"
-
-// defining error code more informations under
-// http://www.gnu.org/software/libc/manual/html_node/Error-Codes.html
-
-// Redirection to EAGAIN
-//
-// Quate:
-// 	"Resource temporarily unavailable; the call might work if you
-// 	try again later. The macro EWOULDBLOCK is another name for EAGAIN;
-// 	they are always the same in the GNU C Library.
-//
-// 	This error can happen in a few different situations:
-//
-// 	An operation that would block was attempted on an object
-// 	that has non-blocking mode selected. Trying the same operation
-// 	again will block until some external condition makes it possible
-// 	to read, write, or connect (whatever the operation). You can
-// 	use select to find out when the operation will be possible;
-// 	see Waiting for I/O.
-//
-// 	Portability Note: In many older Unix systems, this condition
-// 	was indicated by EWOULDBLOCK, which was a distinct error code
-// 	different from EAGAIN. To make your program portable, you
-// 	should check for both codes and treat them the same.
-// 	A temporary resource shortage made an operation impossible.
-// 	fork can return this error. It indicates that the shortage
-// 	is expected to pass, so your program can try the call again
-// 	later and it may succeed. It is probably a good idea to delay
-// 	for a few seconds before trying it again, to allow time for
-// 	other processes to release scarce resources. Such
-// 	shortages are usually fairly serious and affect the whole
-// 	system, so usually an interactive program should report
-// 	the error to the user and return to its command loop. "
-#define EUDAQ_ERROR_Resource_temp_unavailable EWOULDBLOCK
-
-// 	An operation that cannot complete immediately was initiated
-// 	on an object that has non-blocking mode selected. Some
-// 	functions that must always block (such as connect; see
-// 	Connecting) never return EAGAIN. Instead, they return
-// 	EINPROGRESS to indicate that the operation has begun and
-// 	will take some time. Attempts to manipulate the object
-// 	before the call completes return EALREADY. You can use the
-// 	select function to find out when the pending operation has
-// 	completed; see Waiting for I/O.
-#define EUDAQ_ERROR_Operation_progress EINPROGRESS
-
-// 	Interrupted function call;
-// 	an asynchronous signal occurred and
-// 	prevented completion of the call.
-// 	When this happens, you should try
-// 	the call again.
-// 	You can choose to have functions resume
-// 	after a signal that is handled, rather
-// 	than failing with EINTR; see Interrupted
-// 	Primitives.
-#define EUDAQ_ERROR_Interrupted_function_call EINTR
-
-#define EUDAQ_ERROR_NO_DATA_RECEIVED -1
-
 #endif
 
 // print debug messages that are optimized out if DEBUG_TRANSPORT is not set:
@@ -203,14 +108,17 @@ namespace eudaq {
 
         if (result > 0) {
           sent += result;
-        } else if (result < 0 &&
-                   (LastSockError() == EUDAQ_ERROR_Resource_temp_unavailable ||
-                    LastSockError() == EUDAQ_ERROR_Interrupted_function_call)) {
+        }
+	else if (result < 0 &&
+		 (LastSockError() == EUDAQ_ERROR_Resource_temp_unavailable ||
+		  LastSockError() == EUDAQ_ERROR_Interrupted_function_call)){
           // continue
-        } else if (result == 0) {
-          EUDAQ_THROW_NOLOG("Connection reset by peer");
-        } else if (result < 0) {
-          EUDAQ_THROW_NOLOG(LastSockErrorString("Error sending data"));
+        }
+	else if (result == 0) {
+          EUDAQ_THROW_NOLOG("TransportTCP:: Connection reset by peer");
+        }
+	else if (result < 0) {
+          EUDAQ_THROW_NOLOG(LastSockErrorString("TransportTCP:: Error sending data"));
         }
       } while (sent < len);
     }
@@ -267,7 +175,7 @@ namespace eudaq {
 
   std::string ConnectionInfoTCP::getpacket() {
     if (!havepacket())
-      EUDAQ_THROW_NOLOG("No packet available");
+      EUDAQ_THROW_NOLOG("TransprotTCP:: No packet available");
     std::string packet(m_buf, 4, m_len);
     m_buf.erase(0, m_len + 4);
     update_length(true);
@@ -290,8 +198,7 @@ namespace eudaq {
         m_srvsock(socket(PF_INET, SOCK_STREAM, IPPROTO_TCP)),
         m_maxfd(m_srvsock) {
     if (m_srvsock == (SOCKET)-1)
-      EUDAQ_THROW_NOLOG(LastSockErrorString(
-          "Failed to create socket")); //$$ check if (SOCKET)-1 is correct
+      EUDAQ_THROW_NOLOG(LastSockErrorString("TCPServer:: Failed to create socket")); //$$ check if (SOCKET)-1 is correct
     setup_signal();
     FD_ZERO(&m_fdset);
     FD_SET(m_srvsock, &m_fdset);
@@ -306,13 +213,13 @@ namespace eudaq {
 
     if (bind(m_srvsock, (sockaddr *)&addr, sizeof addr)) {
       closesocket(m_srvsock);
-      EUDAQ_THROW_NOLOG(LastSockErrorString("Failed to bind socket: " + param));
+      EUDAQ_THROW_NOLOG(LastSockErrorString("TCPServer:: Failed to bind socket: " + param));
     }
     socklen_t addr_len = sizeof addr;
     if(m_port == 0){
       getsockname(m_srvsock, (sockaddr *)&addr, &addr_len);
       m_port = ntohs(addr.sin_port);
-      EUDAQ_INFO("listening on port " + std::to_string(m_port));
+      EUDAQ_INFO("TCPServer:: Listening on port " + std::to_string(m_port));
     }
     if (listen(m_srvsock, MAXPENDING)){
       closesocket(m_srvsock);
@@ -388,17 +295,17 @@ namespace eudaq {
         // std::cout << "timeout" << std::endl;
       } else if (result < 0 &&
                  LastSockError() != EUDAQ_ERROR_Interrupted_function_call) {
-        std::cout << LastSockErrorString("Error in select()") << std::endl;
+        EUDAQ_THROW_NOLOG(LastSockErrorString("Error in select()"));
       } else if (result > 0) {
 
         if (FD_ISSET(m_srvsock, &tempset)) {
           sockaddr_in addr;
           socklen_t len = sizeof(addr);
-          SOCKET peersock =
-              accept(static_cast<int>(m_srvsock), (sockaddr *)&addr, &len);
+          SOCKET peersock = accept(static_cast<int>(m_srvsock), (sockaddr *)&addr, &len);
           if (peersock == INVALID_SOCKET) {
-            std::cout << LastSockErrorString("Error in accept()") << std::endl;
-          } else {
+	    EUDAQ_THROW_NOLOG(LastSockErrorString("Error in accept()"));
+          }
+	  else {
             FD_SET(peersock, &m_fdset);
             m_maxfd = (m_maxfd < peersock) ? peersock : m_maxfd;
             setup_socket(peersock);

--- a/monitors/onlinemon/include/OnlineMon.hh
+++ b/monitors/onlinemon/include/OnlineMon.hh
@@ -71,7 +71,7 @@ protected:
   // bool _autoReset;
 
 public:
-  RootMonitor(const std::string &runcontrol, const std::string &addr_listen, 
+  RootMonitor(const std::string &runcontrol, 
 	      int x, int y, int w, int h, int argc, int offline,
               const std::string &conffile = "");
   ~RootMonitor() { gApplication->Terminate(); }

--- a/monitors/onlinemon/include/OnlineMon.hh
+++ b/monitors/onlinemon/include/OnlineMon.hh
@@ -19,7 +19,6 @@
 #include "eudaq/OptionParser.hh"
 #endif
 
-
 #include "HitmapCollection.hh"
 #include "CorrelationCollection.hh"
 #include "MonitorPerformanceCollection.hh"
@@ -27,7 +26,6 @@
 #include "ParaMonitorCollection.hh"
 
 #include "OnlineMonWindow.hh"
-//#include "OnlineHistograms.hh"
 #include "SimpleStandardEvent.hh"
 #include "EventSanityChecker.hh"
 #include "OnlineMonConfiguration.hh"
@@ -38,26 +36,44 @@
 #include <string>
 #include <memory>
 
-#ifdef WIN32
-#define EUDAQ_SLEEP(x) Sleep(x * 1000)
-#else
-#define EUDAQ_SLEEP(x) sleep(x)
-#endif
-
 using namespace std;
 
 class OnlineMonWindow;
 class BaseCollection;
 class CheckEOF;
 
-class RootMonitor : private eudaq::Holder<int>,
-                    // public TApplication,
-                    // public TGMainFrame,
-                    public eudaq::Monitor {
+class RootMonitor : public eudaq::Monitor{
   RQ_OBJECT("RootMonitor")
-protected:
-  bool histos_booked;
+public:
+  RootMonitor(const std::string &runcontrol, 
+	      int x, int y, int w, int h, int argc, int offline,
+              const std::string &conffile = "");
+  ~RootMonitor() override;
+  void DoConfigure() override;
+  void DoStartRun() override;
+  void DoStopRun() override;
+  void DoTerminate() override;
+  void DoReceive(eudaq::EventSP) override;
+  
+  void registerSensorInGUI(std::string name, int id);
+  void autoReset(const bool reset);
 
+  void setWriteRoot(const bool write);
+  void setReduce(const unsigned int red);
+  void setUpdate(const unsigned int up);
+  void setCorr_width(const unsigned c_w);
+  void setCorr_planes(const unsigned c_p);
+  void setUseTrack_corr(const bool t_c);
+  void setTracksPerEvent(const unsigned int tracks);
+  void SetSnapShotDir(string s);
+
+  bool getUseTrack_corr() const;
+  unsigned int getTracksPerEvent() const;
+  string GetSnapShotDir() const;
+  OnlineMonWindow *getOnlineMon() const;
+  OnlineMonConfiguration mon_configdata; // FIXME
+private:
+  bool histos_booked;
   std::vector<BaseCollection *> _colls;
   OnlineMonWindow *onlinemon;
   std::string rootfilename;
@@ -66,55 +82,11 @@ protected:
   bool _writeRoot;
   int _offline;
   CheckEOF _checkEOF;
-
   bool _planesInitialized;
-  // bool _autoReset;
-
-public:
-  RootMonitor(const std::string &runcontrol, 
-	      int x, int y, int w, int h, int argc, int offline,
-              const std::string &conffile = "");
-  ~RootMonitor() { gApplication->Terminate(); }
-  void registerSensorInGUI(std::string name, int id);
   HitmapCollection *hmCollection;
   CorrelationCollection *corrCollection;
   EUDAQMonitorCollection *eudaqCollection;
   ParaMonitorCollection *paraCollection;
-
-  OnlineMonWindow *getOnlineMon() { return onlinemon; }
-
-  void DoConfigure() override{
-    auto &param = *GetConfiguration();
-    std::cout << "Configure: " << param.Name() << std::endl;
-  }
-  
-  void DoTerminate() override {
-    gApplication->Terminate();
-  }  
-
-  void DoStartRun() override;
-  void DoStopRun() override;
-  void DoReceive(eudaq::EventSP) override;
-  
-  void setWriteRoot(const bool write) { _writeRoot = write; }
-  void autoReset(const bool reset);
-  void setReduce(const unsigned int red);
-  void setUpdate(const unsigned int up);
-  void setCorr_width(const unsigned c_w) {
-    corrCollection->setWindowWidthForCorrelation(c_w);
-  }
-  void setCorr_planes(const unsigned c_p) {
-    corrCollection->setPlanesNumberForCorrelation(c_p);
-  }
-  void setUseTrack_corr(const bool t_c) { useTrackCorrelator = t_c; }
-  bool getUseTrack_corr() const { return useTrackCorrelator; }
-  void setTracksPerEvent(const unsigned int tracks) { tracksPerEvent = tracks; }
-  unsigned int getTracksPerEvent() const { return tracksPerEvent; }
-
-  void SetSnapShotDir(string s);
-  string GetSnapShotDir();
-  OnlineMonConfiguration mon_configdata; // FIXME
-private:
   string snapshotdir;
   EventSanityChecker myevent; // FIXME
   bool useTrackCorrelator;

--- a/monitors/onlinemon/src/OnlineMon.cxx
+++ b/monitors/onlinemon/src/OnlineMon.cxx
@@ -48,13 +48,12 @@
 #include "eudaq/StdEventConverter.hh"
 using namespace std;
 
-RootMonitor::RootMonitor(const std::string & runcontrol, const std::string &addr_listen,
+RootMonitor::RootMonitor(const std::string & runcontrol,
 			 int /*x*/, int /*y*/, int /*w*/, int /*h*/,
 			 int argc, int offline, const std::string & conffile)
   : eudaq::Holder<int>(argc), eudaq::Monitor("StdEventMonitor", runcontrol), _offline(offline), _planesInitialized(false), onlinemon(NULL){
   if (_offline <= 0)
   {
-    SetServerAddress(addr_listen);
     onlinemon = new OnlineMonWindow(gClient->GetRoot(),800,600);
     if (onlinemon==NULL)
     {
@@ -484,8 +483,6 @@ int main(int argc, const char ** argv) {
       "The address of the RunControl application");
   eudaq::Option<std::string> level(op, "l", "log-level", "NONE", "level",
       "The minimum level for displaying log messages locally");
-  eudaq::Option<std::string> listen(op, "a", "listen-port", "", "address",
-				    "The listenning port this ");
   eudaq::Option<int>             x(op, "x", "left",    100, "pos");
   eudaq::Option<int>             y(op, "y", "top",       0, "pos");
   eudaq::Option<int>             w(op, "w", "width",  1400, "pos");
@@ -503,11 +500,6 @@ int main(int argc, const char ** argv) {
   try {
     op.Parse(argv);
     EUDAQ_LOG_LEVEL(level.Value());
-    uint16_t port = static_cast<uint16_t>(eudaq::str2hash("StdEventMonitor"+rctrl.Value()));
-    std::string addr_listen = "tcp://"+std::to_string(port);
-    if(!listen.Value().empty()){
-      addr_listen = listen.Value();
-    }
 
     if (!rctrl.IsSet()) rctrl.SetValue("null://");
     if (gROOT!=NULL)
@@ -534,7 +526,7 @@ int main(int argc, const char ** argv) {
     }
 
     TApplication theApp("App", &argc, const_cast<char**>(argv),0,0);
-    RootMonitor mon(rctrl.Value(), addr_listen,
+    RootMonitor mon(rctrl.Value(),
 		    x.Value(), y.Value(), w.Value(), h.Value(),
 		    argc, offline.Value(), configfile.Value());
     mon.setWriteRoot(do_rootatend.IsSet());

--- a/monitors/onlinemon/src/OnlineMon.cxx
+++ b/monitors/onlinemon/src/OnlineMon.cxx
@@ -51,7 +51,7 @@ using namespace std;
 RootMonitor::RootMonitor(const std::string & runcontrol,
 			 int /*x*/, int /*y*/, int /*w*/, int /*h*/,
 			 int argc, int offline, const std::string & conffile)
-  : eudaq::Holder<int>(argc), eudaq::Monitor("StdEventMonitor", runcontrol), _offline(offline), _planesInitialized(false), onlinemon(NULL){
+  :eudaq::Monitor("StdEventMonitor", runcontrol), _offline(offline), _planesInitialized(false), onlinemon(NULL){
   if (_offline <= 0)
   {
     onlinemon = new OnlineMonWindow(gClient->GetRoot(),800,600);
@@ -122,6 +122,24 @@ RootMonitor::RootMonitor(const std::string & runcontrol,
 
 }
 
+RootMonitor::~RootMonitor(){
+  gApplication->Terminate();
+}
+
+OnlineMonWindow* RootMonitor::getOnlineMon() const {
+  return onlinemon;
+}
+
+void RootMonitor::setWriteRoot(const bool write) {
+  _writeRoot = write;
+}
+
+void RootMonitor::setCorr_width(const unsigned c_w) {
+  corrCollection->setWindowWidthForCorrelation(c_w);
+}
+void RootMonitor::setCorr_planes(const unsigned c_p) {
+  corrCollection->setPlanesNumberForCorrelation(c_p);
+}
 
 void RootMonitor::setReduce(const unsigned int red) {
   if (_offline <= 0) onlinemon->setReduce(red);
@@ -130,6 +148,32 @@ void RootMonitor::setReduce(const unsigned int red) {
     _colls.at(i)->setReduce(red);
   }
 }
+
+
+void RootMonitor::setUseTrack_corr(const bool t_c) {
+  useTrackCorrelator = t_c;
+}
+
+bool RootMonitor::getUseTrack_corr() const {
+  return useTrackCorrelator;
+}
+
+void RootMonitor::setTracksPerEvent(const unsigned int tracks) {
+  tracksPerEvent = tracks;
+}
+
+unsigned int RootMonitor::getTracksPerEvent() const {
+  return tracksPerEvent;
+}
+
+void RootMonitor::DoConfigure(){
+  auto &param = *GetConfiguration();
+  std::cout << "Configure: " << param.Name() << std::endl;
+}
+
+void RootMonitor::DoTerminate(){
+  gApplication->Terminate();
+}  
 
 void RootMonitor::DoReceive(eudaq::EventSP evsp) {
   auto stdev = std::dynamic_pointer_cast<eudaq::StandardEvent>(evsp);
@@ -340,7 +384,7 @@ void RootMonitor::DoReceive(eudaq::EventSP evsp) {
 #ifdef DEBUG
       cout << "Waiting for booking of Histograms..." << endl;
 #endif
-      EUDAQ_SLEEP(1);
+      std::this_thread::sleep_for(std::chrono::seconds(1));
 #ifdef DEBUG
       cout << "...long enough"<< endl;
 #endif
@@ -471,8 +515,7 @@ void RootMonitor::SetSnapShotDir(string s)
 
 
 //gets the location for the snapshots
-string RootMonitor::GetSnapShotDir()
-{
+string RootMonitor::GetSnapShotDir()const{
   return snapshotdir;
 }
 
@@ -502,29 +545,6 @@ int main(int argc, const char ** argv) {
     EUDAQ_LOG_LEVEL(level.Value());
 
     if (!rctrl.IsSet()) rctrl.SetValue("null://");
-    if (gROOT!=NULL)
-    {
-    //  gROOT->Reset();
-     // gROOT->SetStyle("Plain"); //$$ change
-    }
-    else
-    {
-      cout<<"Global gROOT Object not found" <<endl;
-      exit(-1);
-    }
-    if (gStyle!=NULL)
-    {
-      gStyle->SetPalette(1);
-      gStyle->SetNumberContours(99);
-      gStyle->SetOptStat(1111);
-      gStyle->SetStatH(static_cast<Float_t>(0.15));
-    }
-    else
-    {
-      cout<<"Global gStyle Object not found" <<endl;
-      exit(-1);
-    }
-
     TApplication theApp("App", &argc, const_cast<char**>(argv),0,0);
     RootMonitor mon(rctrl.Value(),
 		    x.Value(), y.Value(), w.Value(), h.Value(),
@@ -541,9 +561,8 @@ int main(int argc, const char ** argv) {
     cout <<"Update Interval :" <<update.Value() <<" ms" <<endl;
     cout <<"Reduce Events   :" <<reduce.Value() <<endl;
     //TODO: run cmd data thread
-
-    mon.StartMonitor();
-    mon.StartCommandReceiver();
+    eudaq::Monitor *m = dynamic_cast<eudaq::Monitor*>(&mon);
+    m->Connect();
     theApp.Run(); //execute
   } catch (...) {
     return op.HandleMainException();

--- a/user/eudet/module/src/TluProducer.cc
+++ b/user/eudet/module/src/TluProducer.cc
@@ -26,15 +26,11 @@ public:
   void DoStopRun() override;
   void DoTerminate() override;
   void DoReset() override;
-
-  void OnStatus() override;
-
-  void MainLoop();
+  void DoStatus() override;
+  void RunLoop() override;
 
   static const uint32_t m_id_factory = eudaq::cstr2hash("TluProducer");
 private:
-
-  std::thread m_thd_run;
   bool m_exit_of_run;
   uint32_t m_trigger_n;
   uint64_t m_ts_last;
@@ -69,7 +65,7 @@ TluProducer::TluProducer(const std::string name, const std::string &runcontrol)
   }
 }
 
-void TluProducer::MainLoop(){
+void TluProducer::RunLoop(){
   bool isbegin = true;
   if (timestamp_per_run)
     m_tlu->ResetTimestamp();
@@ -196,31 +192,22 @@ void TluProducer::DoConfigure() {
 
 void TluProducer::DoStartRun(){
   m_exit_of_run = false;
-  m_thd_run = std::thread(&TluProducer::MainLoop, this);
 }
 
 void TluProducer::DoStopRun(){
   m_exit_of_run = true;
-  if(m_thd_run.joinable())
-    m_thd_run.join();
-  std::cout<<">>>>>>>>>>>>>STOPped\n";
 }
 
 void TluProducer::DoTerminate(){
   m_exit_of_run = true;
-  if(m_thd_run.joinable())
-    m_thd_run.join();
 }
 
 void TluProducer::DoReset(){
   m_exit_of_run = true;
-  if(m_thd_run.joinable())
-    m_thd_run.join();
-
   m_tlu.reset();
 }
 
-void TluProducer::OnStatus(){
+void TluProducer::DoStatus(){
   SetStatusTag("TRIG", std::to_string(m_trigger_n));
   if (m_tlu) {
     SetStatusTag("TIMESTAMP", std::to_string(Timestamp2Seconds(m_tlu->GetTimestamp())));

--- a/user/eudet/module/src/UsbpixrefRawEvent2LCEventConverter.cc
+++ b/user/eudet/module/src/UsbpixrefRawEvent2LCEventConverter.cc
@@ -48,7 +48,7 @@ namespace{
     Register<UsbpixrefRawEvent2LCEventConverter>(UsbpixrefRawEvent2LCEventConverter::m_id_factory);
 }
 
-ATLASFEI4Interpreter<0x00007F00, 0x000000FF> UsbpixrefRawEvent2StdEventConverter::fei4a_intp;
+ATLASFEI4Interpreter<0x00007F00, 0x000000FF> UsbpixrefRawEvent2LCEventConverter::fei4a_intp;
 
 bool UsbpixrefRawEvent2LCEventConverter::
 Converting(eudaq::EventSPC d1, eudaq::LCEventSP d2, eudaq::ConfigurationSPC conf)const {

--- a/user/eudet/module/src/UsbpixrefRawEvent2LCEventConverter.cc
+++ b/user/eudet/module/src/UsbpixrefRawEvent2LCEventConverter.cc
@@ -48,6 +48,8 @@ namespace{
     Register<UsbpixrefRawEvent2LCEventConverter>(UsbpixrefRawEvent2LCEventConverter::m_id_factory);
 }
 
+ATLASFEI4Interpreter<0x00007F00, 0x000000FF> UsbpixrefRawEvent2StdEventConverter::fei4a_intp;
+
 bool UsbpixrefRawEvent2LCEventConverter::
 Converting(eudaq::EventSPC d1, eudaq::LCEventSP d2, eudaq::ConfigurationSPC conf)const {
   auto& lcioEvent = *(d2.get());

--- a/user/eudet/module/src/UsbpixrefRawEvent2StdEventConverter.cc
+++ b/user/eudet/module/src/UsbpixrefRawEvent2StdEventConverter.cc
@@ -49,6 +49,9 @@ namespace{
     Register<UsbpixrefRawEvent2StdEventConverter>(UsbpixrefRawEvent2StdEventConverter::m_id_factory);
 }
 
+
+ATLASFEI4Interpreter<0x00007F00, 0x000000FF> UsbpixrefRawEvent2StdEventConverter::fei4a_intp;
+
 bool UsbpixrefRawEvent2StdEventConverter::
 Converting(eudaq::EventSPC d1, eudaq::StandardEventSP d2, eudaq::ConfigurationSPC conf) const {
   auto ev_raw = std::dynamic_pointer_cast<const eudaq::RawEvent>(d1);

--- a/user/example/module/src/Ex0Producer.cc
+++ b/user/example/module/src/Ex0Producer.cc
@@ -18,7 +18,7 @@ class Ex0Producer : public eudaq::Producer {
   void DoStopRun() override;
   void DoTerminate() override;
   void DoReset() override;
-  void Mainloop();
+  bool RunLoop() override;
   
   static const uint32_t m_id_factory = eudaq::cstr2hash("Ex0Producer");
 private:
@@ -27,7 +27,6 @@ private:
   uint32_t m_plane_id;
   FILE* m_file_lock;
   std::chrono::milliseconds m_ms_busy;
-  std::thread m_thd_run;
   bool m_exit_of_run;
 };
 //----------DOC-MARK-----END*DEC-----DOC-MARK----------
@@ -70,36 +69,29 @@ void Ex0Producer::DoConfigure(){
 //----------DOC-MARK-----BEG*RUN-----DOC-MARK----------
 void Ex0Producer::DoStartRun(){
   m_exit_of_run = false;
-  m_thd_run = std::thread(&Ex0Producer::Mainloop, this);
 }
 //----------DOC-MARK-----BEG*STOP-----DOC-MARK----------
 void Ex0Producer::DoStopRun(){
   m_exit_of_run = true;
-  if(m_thd_run.joinable())
-    m_thd_run.join();
 }
 //----------DOC-MARK-----BEG*RST-----DOC-MARK----------
 void Ex0Producer::DoReset(){
   m_exit_of_run = true;
-  if(m_thd_run.joinable())
-    m_thd_run.join();
+
 #ifndef _WIN32
   flock(fileno(m_file_lock), LOCK_UN);
 #endif
   fclose(m_file_lock);
-  m_thd_run = std::thread();
   m_ms_busy = std::chrono::milliseconds();
   m_exit_of_run = false;
 }
 //----------DOC-MARK-----BEG*TER-----DOC-MARK----------
 void Ex0Producer::DoTerminate(){
   m_exit_of_run = true;
-  if(m_thd_run.joinable())
-    m_thd_run.join();
   fclose(m_file_lock);
 }
 //----------DOC-MARK-----BEG*LOOP-----DOC-MARK----------
-void Ex0Producer::Mainloop(){
+bool Ex0Producer::RunLoop(){
   auto tp_start_run = std::chrono::steady_clock::now();
   uint32_t trigger_n = 0;
   uint8_t x_pixel = 16;

--- a/user/example/module/src/Ex0Producer.cc
+++ b/user/example/module/src/Ex0Producer.cc
@@ -38,7 +38,7 @@ namespace{
 //----------DOC-MARK-----END*REG-----DOC-MARK----------
 //----------DOC-MARK-----BEG*CON-----DOC-MARK----------
 Ex0Producer::Ex0Producer(const std::string & name, const std::string & runcontrol)
-  :eudaq::Producer(name, runcontrol), m_exit_of_run(false){  
+  :eudaq::Producer(name, runcontrol), m_file_lock(0), m_exit_of_run(false){  
 }
 //----------DOC-MARK-----BEG*INI-----DOC-MARK----------
 void Ex0Producer::DoInitialise(){
@@ -77,18 +77,23 @@ void Ex0Producer::DoStopRun(){
 //----------DOC-MARK-----BEG*RST-----DOC-MARK----------
 void Ex0Producer::DoReset(){
   m_exit_of_run = true;
-
+  if(m_file_lock){
 #ifndef _WIN32
-  flock(fileno(m_file_lock), LOCK_UN);
+    flock(fileno(m_file_lock), LOCK_UN);
 #endif
-  fclose(m_file_lock);
+    fclose(m_file_lock);
+    m_file_lock = 0;
+  }
   m_ms_busy = std::chrono::milliseconds();
   m_exit_of_run = false;
 }
 //----------DOC-MARK-----BEG*TER-----DOC-MARK----------
 void Ex0Producer::DoTerminate(){
   m_exit_of_run = true;
-  fclose(m_file_lock);
+  if(m_file_lock){
+    fclose(m_file_lock);
+    m_file_lock = 0;
+  }
 }
 //----------DOC-MARK-----BEG*LOOP-----DOC-MARK----------
 bool Ex0Producer::RunLoop(){

--- a/user/example/module/src/Ex0Producer.cc
+++ b/user/example/module/src/Ex0Producer.cc
@@ -18,7 +18,7 @@ class Ex0Producer : public eudaq::Producer {
   void DoStopRun() override;
   void DoTerminate() override;
   void DoReset() override;
-  bool RunLoop() override;
+  void RunLoop() override;
   
   static const uint32_t m_id_factory = eudaq::cstr2hash("Ex0Producer");
 private:
@@ -96,7 +96,7 @@ void Ex0Producer::DoTerminate(){
   }
 }
 //----------DOC-MARK-----BEG*LOOP-----DOC-MARK----------
-bool Ex0Producer::RunLoop(){
+void Ex0Producer::RunLoop(){
   auto tp_start_run = std::chrono::steady_clock::now();
   uint32_t trigger_n = 0;
   uint8_t x_pixel = 16;

--- a/user/itkstrip/itsroot/src/ROOTProducer.cc
+++ b/user/itkstrip/itsroot/src/ROOTProducer.cc
@@ -128,7 +128,7 @@ void ROOTProducer::Connect2RunControl( const char* name,const char* runcontrol )
   try {
     std::string addr_rc="tcp://"+std::string(runcontrol);
     m_prod=std::unique_ptr<ItsRootProducer>(new ItsRootProducer(name,addr_rc));
-    m_prod->StartCommandReceiver();
+    m_prod->Connect();
   }
   catch(...){
     std::cout<<"unable to connect to runcontrol: "<<runcontrol<<std::endl;
@@ -136,7 +136,7 @@ void ROOTProducer::Connect2RunControl( const char* name,const char* runcontrol )
 }
 
 bool ROOTProducer::isNetConnected(){
-  if(m_prod && m_prod->IsActiveCommandReceiver())
+  if(m_prod && m_prod->IsConnected())
     return true;
   else
     return false;


### PR DESCRIPTION
1.The data processing and data network sending/receiving were in same thread. The monitor could take a signicant time to process data can block data receving. Then dataCollector would blocked, then producer's data-taking gets blocked.
2. New vitural function in for Producer (actually CommandReceiver): RunLoop. If it is overrided in the user Producer, it will be start up in each run and should return when get a stoprun command.
3. Other fix up