### PR TITLE
Currentdev: fixed bug in I2C expander code. Fixed issue with producer not showing firing inputs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ include/*
 extern/*
 lib/*
 logs/*
+test.conf
+test.ini
 
 *.raw
 *.log

--- a/user/eudet/hardware/include/FmctluController.hh
+++ b/user/eudet/hardware/include/FmctluController.hh
@@ -208,8 +208,8 @@ namespace tlu {
       eventnumber(wh&0xffffffff){
     }
 
-    fmctludata(uint32_t w0, uint32_t w1, uint32_t w2, uint32_t w3, uint32_t w4, uint32_t w5) // w0 w1 w2 w3  wl= w0 w1; wh= w2 w3
-      :eventtype((w0>>28)&0xf),
+    fmctludata(uint32_t w0, uint32_t w1, uint32_t w2, uint32_t w3, uint32_t w4, uint32_t w5): // w0 w1 w2 w3  wl= w0 w1; wh= w2 w3
+       eventtype((w0>>28)&0xf),
        input0((w0>>16)&0x1),
        input1((w0>>17)&0x1),
        input2((w0>>18)&0x1),

--- a/user/eudet/hardware/src/FmctluController.cc
+++ b/user/eudet/hardware/src/FmctluController.cc
@@ -110,7 +110,7 @@ namespace tlu {
       if (verbose){
         std::cout << "\tBank " << bank << " Nibble " << nibble << std::endl;
       }
-      oldStatus= m_IOexpander1.getIOReg(bank, false);
+      oldStatus= m_IOexpander1.getOutputs(bank, false);
       mask= 0xF << 4*nibble;
       newStatus= oldStatus & (~mask);
       if (!enable){ // we want to write 0 to activate the outputs so check opposite of "enable"
@@ -119,7 +119,7 @@ namespace tlu {
       if (verbose){
         std::cout << std::hex << "\tOLD " << (int)oldStatus << "\tMask " << (int)mask << "\tNEW " << (int)newStatus << std::dec << std::endl;
       }
-      m_IOexpander1.setIOReg(bank, newStatus, verbose);
+      m_IOexpander1.setOutputs(bank, newStatus, verbose);
     }
     else{
       std::cout << "enableHDMI: connector out of range [1, " << nDUTs << "]" << std::endl;

--- a/user/eudet/misc/fmctlu_runcontrol.conf
+++ b/user/eudet/misc/fmctlu_runcontrol.conf
@@ -1,6 +1,6 @@
 [Producer.fmctlu]
 ## GENERAL PARAMETERS
-verbose= 0
+verbose= 2
 confid= 20171026
 delayStart= 200
 
@@ -20,7 +20,7 @@ LEMOclk = 1
 
 ## TRIGGER CONFIGURATION
 trigMaskHi = 0x00000000
-trigMaskLo = 0x00000020
+trigMaskLo = 0x00000002
 in0_STR = 1
 in0_DEL = 0
 in1_STR = 1

--- a/user/eudet/module/src/FmctluProducer.cc
+++ b/user/eudet/module/src/FmctluProducer.cc
@@ -75,9 +75,9 @@ void FmctluProducer::RunLoop(){
       ev->SetTriggerN(trigger_n);
 
       std::stringstream  triggerss;
-      triggerss<< data->input5 << data->input4 << data->input3 << data->input2 << data->input1 << data->input0;
+      //triggerss<< data->input5 << data->input4 << data->input3 << data->input2 << data->input1 << data->input0;
+      triggerss<< std::to_string(data->input5) << std::to_string(data->input4) << std::to_string(data->input3) << std::to_string(data->input2) << std::to_string(data->input1) << std::to_string(data->input0);
       ev->SetTag("TRIGGER", triggerss.str());
-      //std::cout << "-----> " << static_cast<unsigned>(data->input5) << " " << static_cast<unsigned>(data->input4) << " " << static_cast<unsigned>(data->input3) << " " << static_cast<unsigned>(data->input2) << " " << static_cast<unsigned>(data->input1) << " " << static_cast<unsigned>(data->input0) << " " << std::endl;
       if(m_tlu->IsBufferEmpty()){
       	uint32_t sl0,sl1,sl2,sl3, sl4, sl5, pt;
       	m_tlu->GetScaler(sl0,sl1,sl2,sl3,sl4,sl5);
@@ -89,12 +89,12 @@ void FmctluProducer::RunLoop(){
       	ev->SetTag("SCALER3", std::to_string(sl3));
         ev->SetTag("SCALER4", std::to_string(sl4));
         ev->SetTag("SCALER5", std::to_string(sl5));
-      	ev->SetTag("TRIGGER0", std::to_string(data->input0));
-        ev->SetTag("TRIGGER1", std::to_string(data->input1));
-        ev->SetTag("TRIGGER2", std::to_string(data->input2));
-        ev->SetTag("TRIGGER3", std::to_string(data->input3));
-        ev->SetTag("TRIGGER4", std::to_string(data->input4));
-        ev->SetTag("TRIGGER5", std::to_string(data->input5));
+      	//ev->SetTag("TRIGGER0", std::to_string(data->input0));
+        //ev->SetTag("TRIGGER1", std::to_string(data->input1));
+        //ev->SetTag("TRIGGER2", std::to_string(data->input2));
+        //ev->SetTag("TRIGGER3", std::to_string(data->input3));
+        //ev->SetTag("TRIGGER4", std::to_string(data->input4));
+        //ev->SetTag("TRIGGER5", std::to_string(data->input5));
         ev->SetTag("TYPE", std::to_string(data->eventtype));
 
         if(m_exit_of_run){


### PR DESCRIPTION
- _gitignore_: added test.conf and test.ini. From now on use those files for local tests, only push to _fmctlu_runcontrol.conf_ and _fmctlu_runcontrol.ini_ if there is a meaningful change.

- _FmctluController.cc_ : fixed minor bug in expander configuration, for consistency.

- _FmctluProducer.cc_ : fixed issue with writing of the firing trigger outputs. Up to now the producer was writing an empty string. It should now correctly display a 6-bit boolean string where each bit correspond to an input firing (1) or not (0). Input0 is the LSB.