### PR TITLE
Send command to individual producer

### DIFF
--- a/gui/include/RunControlModel.hh
+++ b/gui/include/RunControlModel.hh
@@ -15,6 +15,7 @@ public:
   void newconnection(eudaq::ConnectionSPC id);
   void disconnected(eudaq::ConnectionSPC id);
   void SetStatus(eudaq::ConnectionSPC id, eudaq::StatusSPC status);
+  eudaq::ConnectionSPC getConnection(const QModelIndex &index);
 private:
   static std::vector<QString> m_str_header;
   std::map<eudaq::ConnectionSPC, eudaq::StatusSPC> m_con_status;

--- a/gui/include/euRun.hh
+++ b/gui/include/euRun.hh
@@ -35,6 +35,7 @@ private slots:
   void on_btnLog_clicked();
   void on_btnLoadInit_clicked();
   void on_btnLoadConf_clicked();
+  void onCustomContextMenu(const QPoint &point);
 private:
   static std::map<int, QString> m_map_state_str;
   std::map<QString, QString> m_map_label_str;
@@ -46,4 +47,5 @@ private:
   std::map<eudaq::ConnectionSPC, eudaq::StatusSPC> m_map_conn_status_last;
   uint32_t m_run_n_qsettings;
   bool m_lastexit_success;
+  QMenu* contextMenu;
 };

--- a/gui/include/euRun.hh
+++ b/gui/include/euRun.hh
@@ -37,6 +37,8 @@ private slots:
   void on_btnLoadConf_clicked();
   void onCustomContextMenu(const QPoint &point);
 private:
+  bool loadInitFile();
+  bool loadConfigFile();
   static std::map<int, QString> m_map_state_str;
   std::map<QString, QString> m_map_label_str;
   eudaq::RunControlUP m_rc;

--- a/gui/src/RunControlModel.cc
+++ b/gui/src/RunControlModel.cc
@@ -97,3 +97,17 @@ QVariant RunControlModel::headerData(int section, Qt::Orientation orientation,
   }
   return QVariant();
 }
+
+eudaq::ConnectionSPC RunControlModel::getConnection(const QModelIndex &index){
+  auto col_n = index.column();
+  auto row_n = index.row();
+  
+  if(row_n<m_con_status.size() && col_n<m_str_header.size()){
+    auto it = m_con_status.begin();
+    for(size_t i = 0; i< row_n; i++){
+      it++;
+    }
+    auto &con = it->first;	
+    return con;
+    }
+};

--- a/gui/src/euRun.cc
+++ b/gui/src/euRun.cc
@@ -323,15 +323,74 @@ std::map<int, QString> RunControlGUI::m_map_state_str ={
      "<font size=12 color='darkred'><b>Current State: Error </b></font>"}
 };
 
+
 void RunControlGUI::onCustomContextMenu(const QPoint &point)
 {
     QModelIndex index = viewConn->indexAt(point);
+    if(index.isValid()) {
     QMenu *contextMenu = new QMenu(viewConn);	
+
+    if(!m_rc->GetInitConfiguration()){
+	loadInitFile();
+    }
+    if(m_rc->GetInitConfiguration()){
+	QAction *initialiseAction = new QAction("Initialise", this);
+	connect(initialiseAction, &QAction::triggered, this, [this,index]() {m_rc->InitialiseSingleConnection(m_model_conns.getConnection(index));});
+	contextMenu->addAction(initialiseAction);		
+    } 
+
+    if(!m_rc->GetConfiguration()){
+	loadConfigFile();
+    }    
+    if(m_rc->GetConfiguration()){
+	QAction *configureAction = new QAction("Configure", this);
+	connect(configureAction, &QAction::triggered, this, [this,index]() {m_rc->ConfigureSingleConnection(m_model_conns.getConnection(index));});
+	contextMenu->addAction(configureAction);		
+    }
+    
+    QAction *startAction = new QAction("Start", this);
+    connect(startAction, &QAction::triggered, this, [this,index]() {m_rc->StartSingleConnection(m_model_conns.getConnection(index));});
+    contextMenu->addAction(startAction);	    
+    
+    QAction *stopAction = new QAction("Stop", this);
+    connect(stopAction, &QAction::triggered, this, [this,index]() {m_rc->StopSingleConnection(m_model_conns.getConnection(index));});
+    contextMenu->addAction(stopAction);	    
+    
     QAction *resetAction = new QAction("Reset", this);
     connect(resetAction, &QAction::triggered, this, [this,index]() {m_rc->ResetSingleConnection(m_model_conns.getConnection(index));});
     contextMenu->addAction(resetAction);		
+    
     QAction *terminateAction = new QAction("Terminate", this);
     connect(terminateAction, &QAction::triggered, this, [this,index]() {m_rc->TerminateSingleConnection(m_model_conns.getConnection(index));});
     contextMenu->addAction(terminateAction);	
+    
     contextMenu->exec(viewConn->viewport()->mapToGlobal(point));
+    }
+    
+}
+
+bool RunControlGUI::loadInitFile() {
+  std::string settings = txtInitFileName->text().toStdString();
+  QFileInfo check_file(txtInitFileName->text());
+  if(!check_file.exists() || !check_file.isFile()){
+    QMessageBox::warning(NULL, "ERROR", "Init file does not exist.");
+    return false;
+  }
+  if(m_rc){
+    m_rc->ReadInitilizeFile(settings);
+  }
+  return true;  
+}
+
+bool RunControlGUI::loadConfigFile() {
+  std::string settings = txtConfigFileName->text().toStdString();
+  QFileInfo check_file(txtConfigFileName->text());
+  if(!check_file.exists() || !check_file.isFile()){
+    QMessageBox::warning(NULL, "ERROR", "Config file does not exist.");
+    return false;
+  }
+  if(m_rc){
+    m_rc->ReadConfigureFile(settings);
+  }
+  return true;
 }

--- a/gui/src/euRun.cc
+++ b/gui/src/euRun.cc
@@ -36,6 +36,9 @@ RunControlGUI::RunControlGUI()
   viewConn->setModel(&m_model_conns);
   viewConn->setItemDelegate(&m_delegate);
   
+  viewConn->setContextMenuPolicy(Qt::CustomContextMenu);
+  connect(viewConn, SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(onCustomContextMenu(const QPoint &)));
+  
   QRect geom(-1,-1, 150, 200);
   QRect geom_from_last_program_run;
   QSettings settings("EUDAQ collaboration", "EUDAQ");
@@ -319,3 +322,16 @@ std::map<int, QString> RunControlGUI::m_map_state_str ={
     {eudaq::Status::STATE_ERROR,
      "<font size=12 color='darkred'><b>Current State: Error </b></font>"}
 };
+
+void RunControlGUI::onCustomContextMenu(const QPoint &point)
+{
+    QModelIndex index = viewConn->indexAt(point);
+    QMenu *contextMenu = new QMenu(viewConn);	
+    QAction *resetAction = new QAction("Reset", this);
+    connect(resetAction, &QAction::triggered, this, [this,index]() {m_rc->ResetSingleConnection(m_model_conns.getConnection(index));});
+    contextMenu->addAction(resetAction);		
+    QAction *terminateAction = new QAction("Terminate", this);
+    connect(terminateAction, &QAction::triggered, this, [this,index]() {m_rc->TerminateSingleConnection(m_model_conns.getConnection(index));});
+    contextMenu->addAction(terminateAction);	
+    contextMenu->exec(viewConn->viewport()->mapToGlobal(point));
+}

--- a/main/lib/core/include/eudaq/RunControl.hh
+++ b/main/lib/core/include/eudaq/RunControl.hh
@@ -39,7 +39,9 @@ namespace eudaq {
     virtual void StartRun(); 
     virtual void StopRun();
     virtual void Reset();
+    virtual void ResetSingleConnection(ConnectionSPC id);  
     virtual void Terminate();
+    virtual void TerminateSingleConnection(ConnectionSPC id);
     
     //run in m_thd_server thread
     virtual void DoConnect(ConnectionSPC con) {}

--- a/main/lib/core/include/eudaq/RunControl.hh
+++ b/main/lib/core/include/eudaq/RunControl.hh
@@ -35,9 +35,13 @@ namespace eudaq {
     
     //run in user thread
     virtual void Initialise();
+    virtual void InitialiseSingleConnection(ConnectionSPC id);  
     virtual void Configure();
+    virtual void ConfigureSingleConnection(ConnectionSPC id);  
     virtual void StartRun(); 
+    virtual void StartSingleConnection(ConnectionSPC id);
     virtual void StopRun();
+    virtual void StopSingleConnection(ConnectionSPC id);
     virtual void Reset();
     virtual void ResetSingleConnection(ConnectionSPC id);  
     virtual void Terminate();

--- a/main/lib/core/src/RunControl.cc
+++ b/main/lib/core/src/RunControl.cc
@@ -138,6 +138,12 @@ namespace eudaq {
     m_listening = true;
     SendCommand("RESET", "");
   }
+  
+  void RunControl::ResetSingleConnection(ConnectionSPC id) {
+    EUDAQ_INFO("Processing Reset command for connection ");
+    m_listening = true;	  
+    SendCommand("RESET", "", id);
+  }  
 
   void RunControl::StartRun(){
     EUDAQ_INFO("Processing StartRun command for RUN #" + std::to_string(m_run_n));
@@ -247,7 +253,13 @@ namespace eudaq {
     std::this_thread::sleep_for(std::chrono::seconds(1));
     CloseRunControl();
   }
-
+  
+  void RunControl::TerminateSingleConnection(ConnectionSPC id) {
+    EUDAQ_INFO("Processing Terminate command for connection ");
+    SendCommand("TERMINATE", "", id);
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+  }
+  
   void RunControl::SendCommand(const std::string &cmd, const std::string &param,
                                ConnectionSPC id){
     std::unique_lock<std::mutex> lk(m_mtx_sendcmd);    

--- a/main/lib/core/src/RunControl.cc
+++ b/main/lib/core/src/RunControl.cc
@@ -81,6 +81,42 @@ namespace eudaq {
     for(auto &conn: conn_to_init)
       SendCommand("INIT", to_string(*m_conf_init), conn);
   }
+
+  void RunControl::InitialiseSingleConnection(ConnectionSPC id) {  
+    EUDAQ_INFO("Processing Initialise command");
+    std::unique_lock<std::mutex> lk(m_mtx_conn);
+	  
+    auto st = m_conn_status[id]->GetState();
+    if(st != Status::STATE_UNINIT && st != Status::STATE_UNCONF){
+      	EUDAQ_ERROR(id->GetName()+" is not Status::STATE_UNINIT OR Status::STATE_UNCONF");
+	//TODO:: EUDAQ_THROW
+	return;
+    }
+    lk.unlock();
+
+    std::string conn_type = id->GetType();
+    std::string conn_name = id->GetName();
+    std::string conn_addr = id->GetRemote();
+    if(conn_type == "LogCollector"){
+	lk.lock();
+	std::string server_addr = m_conn_status[id]->GetTag("_SERVER");
+	lk.unlock();
+	if(server_addr.find("tcp://") == 0 && conn_addr.find("tcp://") == 0){
+	  server_addr = conn_addr.substr(0, conn_addr.find_last_not_of("0123456789"))
+	    + ":"
+	    + server_addr.substr(server_addr.find_last_not_of("0123456789")+1);
+	}
+	std::string server_name = conn_type+"."+conn_name;
+	if(server_name=="LogCollector.log" && !server_addr.empty()){
+	  m_conf_init->SetSection("");
+	  m_conf_init->SetString("EUDAQ_LOG_ADDR", server_addr);
+	  SendCommand("LOG", server_addr);
+	}
+      }
+    m_conf_init->SetSection("RunControl"); //TODO: RunControl section must exist
+      std::cout << "sending command" << std::endl;
+    SendCommand("INIT", to_string(*m_conf_init), id);	  
+  }
   
   void RunControl::Configure(){
     EUDAQ_INFO("Processing Configure command");
@@ -121,6 +157,37 @@ namespace eudaq {
     m_conf->SetSection("RunControl"); //TODO: RunControl section must exist
     for(auto &conn: conn_to_conf)
       SendCommand("CONFIG", to_string(*m_conf), conn);
+  }
+  
+  void RunControl::ConfigureSingleConnection(ConnectionSPC id) {  
+    EUDAQ_INFO("Processing Configure command for connection ");
+    std::unique_lock<std::mutex> lk(m_mtx_conn);
+    auto st = m_conn_status[id]->GetState();
+    if(st != Status::STATE_UNCONF && st != Status::STATE_CONF){
+	EUDAQ_ERROR(id->GetName()+" is not Status::STATE_UNCONF OR Status::STATE_CONF, skipped");
+	//TODO:: EUDAQ_THROW
+	return;
+    }
+    lk.unlock();
+    m_conf->SetSection("");
+
+    std::string conn_type = id->GetType();
+    std::string conn_name = id->GetName();
+    std::string conn_addr = id->GetRemote();
+    if(conn_type == "DataCollector" || conn_type == "LogCollector" || conn_type == "Monitor"){
+	lk.lock();
+	std::string server_addr = m_conn_status[id]->GetTag("_SERVER");
+	lk.unlock();
+	if(server_addr.find("tcp://") == 0 && conn_addr.find("tcp://") == 0){
+	  server_addr = conn_addr.substr(0, conn_addr.find_last_not_of("0123456789"))
+	    + ":"
+	    + server_addr.substr(server_addr.find_last_not_of("0123456789")+1);
+	}
+	std::string server_name = conn_type+"."+conn_name;
+	m_conf->SetString(server_name, server_addr);
+    }
+    m_conf->SetSection("RunControl"); //TODO: RunControl section must exist
+    SendCommand("CONFIG", to_string(*m_conf), id);	  
   }
 
   void RunControl::ReadConfigureFile(const std::string &path){
@@ -204,9 +271,22 @@ namespace eudaq {
       }
     }
   }
+  
+  void RunControl::StartSingleConnection(ConnectionSPC id) {  
+    EUDAQ_INFO(std::string("Processing StartRun command for connection ") + std::string(" and RUN #") + std::to_string(m_run_n));
+    std::unique_lock<std::mutex> lk(m_mtx_conn);
+    auto st = m_conn_status[id]->GetState();
+    if(st != Status::STATE_CONF){
+	EUDAQ_ERROR(id->GetName()+" is not Status::STATE_CONF, skipped");
+	//TODO:: EUDAQ_THROW
+    }
+    lk.unlock();
+    
+    SendCommand("START", to_string(m_run_n), id);	  
+  }
 
   void RunControl::StopRun(){
-    EUDAQ_INFO("Processing StartRun command for RUN #" + std::to_string(m_run_n));
+    EUDAQ_INFO("Processing StopRun command for RUN #" + std::to_string(m_run_n));
     m_listening = true;
     m_run_n ++;
     std::vector<ConnectionSPC> conn_to_stop;
@@ -244,6 +324,19 @@ namespace eudaq {
 	SendCommand("STOP", "", conn);
       }
     }
+  }
+  
+  void RunControl::StopSingleConnection(ConnectionSPC id) {  
+    EUDAQ_INFO(std::string("Processing StopRun command for connection ") + std::string("and RUN #") + std::to_string(m_run_n));
+    std::unique_lock<std::mutex> lk(m_mtx_conn);
+    auto st = m_conn_status[id]->GetState();
+    if(st != Status::STATE_RUNNING){
+	EUDAQ_ERROR(id->GetName()+" is not Status::STATE_RUNNING, skipped");
+	//TODO:: EUDAQ_THROW
+      }
+    lk.unlock();
+
+    SendCommand("STOP", "", id);	  
   }
 
   void RunControl::Terminate() {

--- a/user/eudet/hardware/include/NiController.hh
+++ b/user/eudet/hardware/include/NiController.hh
@@ -36,7 +36,7 @@ typedef int SOCKET;
 class NiController {
 
 public:
-  void GetProduserHostInfo();
+  void GetProducerHostInfo();
   void Start();
   void Stop();
   void DatatransportClientSocket_Open(const std::string& addr, uint16_t port);

--- a/user/eudet/hardware/src/NiController.cc
+++ b/user/eudet/hardware/src/NiController.cc
@@ -47,7 +47,7 @@ unsigned char start[5] = "star";
 unsigned char stop[5] = "stop";
 
 
-void NiController::GetProduserHostInfo() {
+void NiController::GetProducerHostInfo() {
   /*** get Producer information, NAME and INET ADDRESS ***/
   char ThisHost[80];
   struct hostent *hclient;

--- a/user/eudet/module/src/NiProducer.cc
+++ b/user/eudet/module/src/NiProducer.cc
@@ -123,7 +123,7 @@ void NiProducer::DoConfigure() {
   auto conf = GetConfiguration();  
   if (!m_configured) {
     ni_control = std::make_shared<NiController>();
-    ni_control->GetProduserHostInfo();
+    ni_control->GetProducerHostInfo();
     std::string addr = conf->Get("NiIPaddr", "localhost");
     uint16_t port = conf->Get("NiConfigSocketPort", 49248);
     ni_control->ConfigClientSocket_Open(addr, port);


### PR DESCRIPTION
This addresses issue #409 : Right click on any connection offers the possibility to send "Reset" or "Terminate" to this particular command receiver only. Testing with ni producer (without attached hardware) shows unexpected implementation within ni producer: Instead of propagating error to run control it only sends message, waits 60 seconds and terminates. It should use SetState explicitly. Up to that step when it ends in error (and also individual reset does not work...needs follow-up) the individual terminate works fine. Could be also easily extended to individual init and config (and start/stop for slowproducers).  What needs checking is whether it does not break the FSM logic --> consequences for global state.