### PR TITLE
RunControl: add config parameter (EUDAQ_CTRL_PRODUCER_LAST_START) to …

### DIFF
--- a/main/lib/core/src/RunControl.cc
+++ b/main/lib/core/src/RunControl.cc
@@ -114,7 +114,6 @@ namespace eudaq {
 	}
       }
     m_conf_init->SetSection("RunControl"); //TODO: RunControl section must exist
-      std::cout << "sending command" << std::endl;
     SendCommand("INIT", to_string(*m_conf_init), id);	  
   }
   
@@ -278,7 +277,6 @@ namespace eudaq {
 
     auto tp_timeout = std::chrono::steady_clock::now()
       + std::chrono::seconds(60);
-    std::cout<< ">>>>>>>>>>>>>>>>>>>>>>>"<< producer_last_start<<std::endl;
     for(auto &conn :conn_to_run){
       if(conn->GetName() == producer_last_start){
 	continue;
@@ -292,7 +290,6 @@ namespace eudaq {
 	  std::this_thread::sleep_for(std::chrono::milliseconds(100));
 	  continue;
 	}else{
-	  std::cout<< ">>>>>>>>>>>>>>>>>>>>"<<conn->GetName() << "is running"<<std::endl;
 	  break;
 	}
       }

--- a/main/lib/core/src/RunControl.cc
+++ b/main/lib/core/src/RunControl.cc
@@ -187,7 +187,7 @@ namespace eudaq {
 	m_conf->SetString(server_name, server_addr);
     }
     m_conf->SetSection("RunControl"); //TODO: RunControl section must exist
-    SendCommand("CONFIG", to_string(*m_conf), id);	  
+    SendCommand("CONFIG", to_string(*m_conf), id);
   }
 
   void RunControl::ReadConfigureFile(const std::string &path){
@@ -262,11 +262,46 @@ namespace eudaq {
 	}
       }
     }
-    
+
+
     //TODO: make sure datacollector is started before producer. waiting
     std::this_thread::sleep_for(std::chrono::seconds(1));
+    std::string producer_last_start;
+    m_conf->SetSection("RunControl");
+    producer_last_start = m_conf->Get("EUDAQ_CTRL_PRODUCER_LAST_START", producer_last_start);
     for(auto &conn :conn_to_run){
-      if(conn->GetType() == "Producer"){
+      if(conn->GetType() == "Producer" &&
+	 conn->GetName() != producer_last_start){
+	SendCommand("START", to_string(m_run_n), conn);
+      }
+    }
+
+    auto tp_timeout = std::chrono::steady_clock::now()
+      + std::chrono::seconds(60);
+    std::cout<< ">>>>>>>>>>>>>>>>>>>>>>>"<< producer_last_start<<std::endl;
+    for(auto &conn :conn_to_run){
+      if(conn->GetName() == producer_last_start){
+	continue;
+      }
+      while(1){
+	auto st = GetConnectionStatus(conn)->GetState();
+	if(st == Status::STATE_CONF){
+	  if(std::chrono::steady_clock::now()>tp_timeout){
+	    EUDAQ_ERROR("Timesout waiting running status from "+ conn->GetName());
+	  }
+	  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+	  continue;
+	}else{
+	  std::cout<< ">>>>>>>>>>>>>>>>>>>>"<<conn->GetName() << "is running"<<std::endl;
+	  break;
+	}
+      }
+    }
+    
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    for(auto &conn :conn_to_run){
+      if(conn->GetType() == "Producer" &&
+	 conn->GetName() == producer_last_start){
 	SendCommand("START", to_string(m_run_n), conn);
       }
     }

--- a/user/example/misc/Ex0.conf
+++ b/user/example/misc/Ex0.conf
@@ -1,18 +1,21 @@
 # example config file: Ex0.conf
 [RunControl]
 EX0_STOP_RUN_AFTER_N_SECONDS=60
+EUDAQ_CTRL_PRODUCER_LAST_START=my_pd0
 
 [Producer.my_pd0]
 EUDAQ_DC=my_dc
 EX0_PLANE_ID=0
 EX0_DURATION_BUSY_MS=1
 EX0_ENABLE_TRIGERNUMBER=1
+EX0_DEV_LOCK_PATH = mylock0
 
 [Producer.my_pd1]
 EUDAQ_DC=my_dc
 EX0_PLANE_ID=1
 EX0_DURATION_BUSY_MS=1
 EX0_ENABLE_TRIGERNUMBER=1
+EX0_DEV_LOCK_PATH = mylock1
 
 [DataCollector.my_dc]
 EUDAQ_MN=my_mon


### PR DESCRIPTION
…start a producer at last

In eudaq1 by hard code,  the tlu starts later than devices. Since TLU is managered as a nornal producer, the parameter  EUDAQ_CTRL_PRODUCER_LAST_START for runcontrol configuration can make a specified producer start at last when all other producers have reported STATE_RUNNING. 


user/example/misc/Ex0.conf
[RunControl]
EUDAQ_CTRL_PRODUCER_LAST_START=my_pd0
[Producer.my_pd0]
key=value
[Producer.my_pd1]
key=value

