### PR TITLE
[Python interface] Fix get config parameter function and add error checks

### DIFF
--- a/main/python/src/PyProducer.cpp
+++ b/main/python/src/PyProducer.cpp
@@ -163,12 +163,18 @@ extern "C" {
   DLLEXPORT PyProducer* PyProducer_new(char *name, char *rcaddress,unsigned int board_id){return new PyProducer(std::string(name),std::string(rcaddress),board_id);}
   // functions for I/O
   DLLEXPORT void PyProducer_SendEvent(PyProducer *pp, uint8_t* buffer, size_t size){pp->SendEvent(buffer,size);}
-  DLLEXPORT char* PyProducer_GetConfigParameter(PyProducer *pp, char *item){
+  DLLEXPORT int PyProducer_GetConfigParameter(PyProducer *pp, char *item, char *buf, int buf_len){
     std::string value = pp->GetConfigParameter(std::string(item));
-    // convert string to char*
-    char* rv = (char*) malloc(sizeof(char) * (strlen(value.data())+1));
-    strcpy(rv, value.data());
-    return rv;
+    if(value.empty()) // key not found
+    	return -1;
+    // Copy to buffer if it fits
+    if (buf_len > strlen(value.c_str())){
+    	strcpy(buf, value.c_str());
+    	return strlen(value.c_str());
+    }
+    else
+    	return 0;
+
   }
   // functions to report on the current state of the producer
   DLLEXPORT bool PyProducer_IsConfiguring(PyProducer *pp){return pp->IsConfiguring();}

--- a/python/PyEUDAQWrapper.py
+++ b/python/PyEUDAQWrapper.py
@@ -67,7 +67,14 @@ class PyProducer(object):
         data_p = data.ctypes.data_as(POINTER(c_uint8))
         lib.PyProducer_SendEvent(c_void_p(self.obj),data_p,data.nbytes)
     def GetConfigParameter(self, item):
-        return c_char_p(lib.PyProducer_GetConfigParameter(c_void_p(self.obj),create_string_buffer(item))).value
+        buf_len = 1024
+        buf = create_string_buffer(buf_len)
+        str_len = lib.PyProducer_GetConfigParameter(c_void_p(self.obj), create_string_buffer(item), buf, buf_len)
+        if str_len < 0:
+            raise ValueError('Cannot find configuration parameter %s', item)
+        if not str_len:
+            raise NotImplementedError('A configuration parameter with more than %d characters is not supported!', buf_len)
+        return buf.value
     @property
     def Configuring(self):
         return lib.PyProducer_IsConfiguring(c_void_p(self.obj))


### PR DESCRIPTION
Thus far it was not possible to access the Config Parameters using the Python interface. This is fixed with this PR.