### PR TITLE
[Python interface] Add ability to get the actual run number

### DIFF
--- a/main/python/src/PyProducer.cpp
+++ b/main/python/src/PyProducer.cpp
@@ -27,6 +27,11 @@ class PyProducer : public eudaq::Producer {
       m_board_id(boardID), 
       m_config(NULL) 
     {}
+
+    unsigned int GetRunNumber() {
+    	std::cout << "[PyProducer] GetRunNumber "<< m_run<< std::endl;
+    	return m_run;
+    }
   
     void SendEvent(uint8_t* data, size_t size) {
       RawDataEvent ev(m_name, m_run, m_evt++);
@@ -176,6 +181,9 @@ extern "C" {
     	return 0;
 
   }
+
+  DLLEXPORT unsigned int PyProducer_GetRunNumber(PyProducer *pp){return pp->GetRunNumber();}
+
   // functions to report on the current state of the producer
   DLLEXPORT bool PyProducer_IsConfiguring(PyProducer *pp){return pp->IsConfiguring();}
   DLLEXPORT bool PyProducer_IsStartingRun(PyProducer *pp){return pp->IsStartingRun();}

--- a/python/PyEUDAQWrapper.py
+++ b/python/PyEUDAQWrapper.py
@@ -66,6 +66,8 @@ class PyProducer(object):
     def SendEvent(self,data):
         data_p = data.ctypes.data_as(POINTER(c_uint8))
         lib.PyProducer_SendEvent(c_void_p(self.obj),data_p,data.nbytes)
+    def GetRunNumber(self):
+        return lib.PyProducer_GetRunNumber(c_void_p(self.obj))
     def GetConfigParameter(self, item):
         buf_len = 1024
         buf = create_string_buffer(buf_len)


### PR DESCRIPTION
The run number is set after Run Start is issued from run control and can be used e.g. to set an appropriate file name in the python producer, depending on run number.