### PR TITLE
user/eudet: Fraction of data send to the Monitor, set to 10

### DIFF
--- a/main/lib/core/src/DataCollector.cc
+++ b/main/lib/core/src/DataCollector.cc
@@ -79,7 +79,7 @@ namespace eudaq {
       m_fwtype = conf->Get("EUDAQ_FW", "native");
       m_fwpatt = conf->Get("EUDAQ_FW_PATTERN", "$12D_run$6R$X");
       m_dct_n = conf->Get("EUDAQ_ID", m_dct_n);
-      m_fraction = conf->Get("EUDAQ_DATACOL_SEND_MONITOR_FRACTION", 1);
+      m_fraction = conf->Get("EUDAQ_DATACOL_SEND_MONITOR_FRACTION", 10);
       DoConfigure();
       CommandReceiver::OnConfigure();
     }catch (const Exception &e) {
@@ -163,6 +163,7 @@ namespace eudaq {
     
   void DataCollector::OnStatus(){
     SetStatusTag("EventN", std::to_string(m_evt_c));
+    SetStatusTag("MonitorEventN", std::to_string(m_evt_c/m_fraction));
     DoStatus();
     // if(m_writer && m_writer->FileBytes()){
     //   SetStatusTag("FILEBYTES", std::to_string(m_writer->FileBytes()));

--- a/user/eudet/misc/conf/eudet_tlu/autotrigger/eudet_one-DC.conf
+++ b/user/eudet/misc/conf/eudet_tlu/autotrigger/eudet_one-DC.conf
@@ -1,6 +1,13 @@
 [RunControl]
 EUDAQ_CTRL_PRODUCER_LAST_START = eudet_tlu
 
+# to start with ITK run control, here 02_eudet_tlu_telescope_itk-rc
+# TODO: rename it and implement this in the standard RunControl or TeleRunControl
+#ITSRC_STOP_RUN_MAX_EVENT = 1000000
+#ITSRC_STOP_RUN_CHECK_FULLNAME = DataCollector.one_dc
+#ITSRC_NEXT_RUN_CONF_FILE = /opt/eudaq2/user/eudet/misc/conf/eudet_tlu/beam/eudet_one-DC.conf
+#ITSRC_STOP_RUN_MIN_SECOND = 20 
+
 [LogCollector.log]
 
 [Producer.eudet_tlu]
@@ -31,6 +38,7 @@ DISABLE_PRINT = 1
 
 [DataCollector.one_dc]
 EUDAQ_MN = StdEventMonitor
+EUDAQ_DATACOL_SEND_MONITOR_FRACTION = 10
 EUDAQ_FW = native
 EUDAQ_FW_PATTERN = /opt/eudaq2/data/run$6R_$12D$X    
 DISABLE_PRINT = 1

--- a/user/eudet/misc/conf/eudet_tlu/beam/eudet_one-DC.conf
+++ b/user/eudet/misc/conf/eudet_tlu/beam/eudet_one-DC.conf
@@ -1,6 +1,13 @@
 [RunControl]
 EUDAQ_CTRL_PRODUCER_LAST_START = eudet_tlu
 
+# to start with ITK run control, here 02_eudet_tlu_telescope_itk-rc
+# TODO: rename it and implement this in the standard RunControl or TeleRunControl
+#ITSRC_STOP_RUN_MAX_EVENT = 1000000
+#ITSRC_STOP_RUN_CHECK_FULLNAME = DataCollector.one_dc
+#ITSRC_NEXT_RUN_CONF_FILE = /opt/eudaq2/user/eudet/misc/conf/eudet_tlu/beam/eudet_one-DC.conf
+#ITSRC_STOP_RUN_MIN_SECOND = 20 
+
 [LogCollector.log]
 
 [Producer.eudet_tlu]
@@ -26,6 +33,7 @@ DISABLE_PRINT = 1
 
 [DataCollector.one_dc]
 EUDAQ_MN = StdEventMonitor
+EUDAQ_DATACOL_SEND_MONITOR_FRACTION = 10
 EUDAQ_FW = native
 EUDAQ_FW_PATTERN = /opt/eudaq2/data/run$6R_$12D$X    
 DISABLE_PRINT = 1

--- a/user/eudet/misc/starting_scripts/02_eudet_tlu_telescope_itk-rc
+++ b/user/eudet/misc/starting_scripts/02_eudet_tlu_telescope_itk-rc
@@ -1,0 +1,23 @@
+# Start Run Control
+xterm -T "Run Control" -e 'euRun -n ItkstripRunControl' &
+sleep 2 
+
+# Start Logger
+xterm -T "Log Collector" -e 'euLog -r tcp://192.168.22.1' &
+sleep 1
+
+# Start one DataCollector
+# name (-t) in conf file
+xterm -T "Data Collector TLU" -e 'euCliCollector -n TriggerIDSyncDataCollector -t one_dc -r tcp://192.168.22.1:44000' &
+#xterm -T "Data Collector TLU" -e 'euCliCollector -n EventIDSyncDataCollector -t one_dc -r tcp://192.168.22.1:44000' &
+sleep 1
+
+# Start TLU Producer
+xterm -T "EUDET TLU Producer" -e 'euCliProducer -n EudetTluProducer -t eudet_tlu -r tcp://192.168.22.1:44000' & 
+
+# Start NI Producer locally connect to LV via TCP/IP
+xterm -T "NI/Mimosa Producer" -e 'euCliProducer -n NiProducer -t ni_mimosa -r tcp://192.168.22.1:44000' &
+sleep 1
+
+# OnlineMonitor
+xterm -T "Online Monitor" -e 'StdEventMonitor -t StdEventMonitor -r tcp://192.168.22.1' & 


### PR DESCRIPTION
For the beam telescope at high continuous rate, the Logger run into a buffer limit due to the OnlineMonitor. Thus, the fraction of data can be set by the parameter EUDAQ_DATACOL_SEND_MONITOR_FRACTION in the DataCollector.

(And: work around solution for automatic run restart from atlasitk runcontrol, as a ToDo for user/eudet or even global.) 