### PR TITLE
AIDA: Add timestamps to StdPlane pixels & StdEvent

### DIFF
--- a/main/lib/core/include/eudaq/StandardEvent.hh
+++ b/main/lib/core/include/eudaq/StandardEvent.hh
@@ -30,35 +30,35 @@ namespace eudaq {
     virtual void Print(std::ostream & os,size_t offset = 0) const;
 
     /**
-     * @brief Funtion to retrieve begin of this event in nanosecons
+     * @brief Funtion to retrieve begin of this event in picosecons
      * @return Start time of this event
      */
-    double GetTimeBegin() const;
+    uint64_t GetTimeBegin() const;
 
     /**
-     * @brief Funtion to retrieve end of this event in nanosecons
+     * @brief Funtion to retrieve end of this event in picosecons
      * @return End time of this event
      */
-    double GetTimeEnd() const;
+    uint64_t GetTimeEnd() const;
 
     /**
-     * @brief Set begin time of event in nanoseconds
-     * @param begin Begin of events in nanoseconds
+     * @brief Set begin time of event in picoseconds
+     * @param begin Begin of events in picoseconds
      */
-    void SetTimeBegin(double begin) { time_begin = begin; };
+    void SetTimeBegin(uint64_t begin) { time_begin = begin; };
 
     /**
-     * @brief Set end time of event in nanoseconds
-     * @param end End of events in nanoseconds
+     * @brief Set end time of event in picoseconds
+     * @param end End of events in picoseconds
      */
-     void SetTimeEnd(double end) { time_end = end; };
+     void SetTimeEnd(uint64_t end) { time_end = end; };
 
     static StdEventSP MakeShared();
     static const uint32_t m_id_factory = cstr2hash("StandardEvent");
 
   private:
     std::vector<StandardPlane> m_planes;
-    double time_begin, time_end;
+    uint64_t time_begin, time_end;
   };
 
   inline std::ostream &operator<<(std::ostream &os, const StandardPlane &pl) {

--- a/main/lib/core/include/eudaq/StandardEvent.hh
+++ b/main/lib/core/include/eudaq/StandardEvent.hh
@@ -10,12 +10,12 @@
 
 namespace eudaq {
   class StandardEvent;
-  
+
   using StdEventUP = Factory<StandardEvent>::UP;
   using StdEventSP = Factory<StandardEvent>::SP;
   using StdEventSPC = Factory<StandardEvent>::SPC;
   using StandardEventSP = StdEventSP;
-  using StandardEventSPC = StdEventSPC;  
+  using StandardEventSPC = StdEventSPC;
 
   class DLLEXPORT StandardEvent : public Event {
     public:
@@ -28,12 +28,37 @@ namespace eudaq {
     StandardPlane &GetPlane(size_t i);
     virtual void Serialize(Serializer &) const;
     virtual void Print(std::ostream & os,size_t offset = 0) const;
-    
-    static StdEventSP MakeShared();    
+
+    /**
+     * @brief Funtion to retrieve begin of this event in nanosecons
+     * @return Start time of this event
+     */
+    double GetTimeBegin() const;
+
+    /**
+     * @brief Funtion to retrieve end of this event in nanosecons
+     * @return End time of this event
+     */
+    double GetTimeEnd() const;
+
+    /**
+     * @brief Set begin time of event in nanoseconds
+     * @param begin Begin of events in nanoseconds
+     */
+    void SetTimeBegin(double begin) { time_begin = begin; };
+
+    /**
+     * @brief Set end time of event in nanoseconds
+     * @param end End of events in nanoseconds
+     */
+     void SetTimeEnd(double end) { time_end = end; };
+
+    static StdEventSP MakeShared();
     static const uint32_t m_id_factory = cstr2hash("StandardEvent");
 
   private:
     std::vector<StandardPlane> m_planes;
+    double time_begin, time_end;
   };
 
   inline std::ostream &operator<<(std::ostream &os, const StandardPlane &pl) {

--- a/main/lib/core/include/eudaq/StandardPlane.hh
+++ b/main/lib/core/include/eudaq/StandardPlane.hh
@@ -62,7 +62,7 @@ namespace eudaq {
 
     void SetPixelHelper(uint32_t index, uint32_t x, uint32_t y, double pix, uint64_t time_ps,
                         bool pivot, uint32_t frame);
-    void PushPixelHelper(uint32_t x, uint32_t y, double pix, double time_ps, bool pivot,
+    void PushPixelHelper(uint32_t x, uint32_t y, double pix, uint64_t time_ps, bool pivot,
                          uint32_t frame);
     double GetPixel(uint32_t index, uint32_t frame) const;
     double GetPixel(uint32_t index) const;

--- a/main/lib/core/include/eudaq/StandardPlane.hh
+++ b/main/lib/core/include/eudaq/StandardPlane.hh
@@ -37,26 +37,32 @@ namespace eudaq {
     template <typename T>
       void SetPixel(uint32_t index, uint32_t x, uint32_t y, T pix,
 		    bool pivot = false, uint32_t frame = 0) {
-      SetPixelHelper(index, x, y, (double)pix, pivot, frame);
+      SetPixelHelper(index, x, y, (double)pix, 0.0, pivot, frame);
     }
+    template <typename T>
+      void SetPixel(uint32_t index, uint32_t x, uint32_t y, T pix, double time,
+		    bool pivot = false, uint32_t frame = 0) {
+      SetPixelHelper(index, x, y, (double)pix, time, pivot, frame);
+    }
+
     template <typename T>
       void SetPixel(uint32_t index, uint32_t x, uint32_t y, T pix,
 		    uint32_t frame) {
-      SetPixelHelper(index, x, y, (double)pix, false, frame);
+      SetPixelHelper(index, x, y, (double)pix, 0.0, false, frame);
     }
     template <typename T>
-      void PushPixel(uint32_t x, uint32_t y, T pix, bool pivot = false,
+      void PushPixel(uint32_t x, uint32_t y, T pix, double time = 0.0, bool pivot = false,
 		     uint32_t frame = 0) {
-      PushPixelHelper(x, y, (double)pix, pivot, frame);
+      PushPixelHelper(x, y, (double)pix, time, pivot, frame);
     }
     template <typename T>
       void PushPixel(uint32_t x, uint32_t y, T pix, uint32_t frame) {
-      PushPixelHelper(x, y, (double)pix, false, frame);
+      PushPixelHelper(x, y, (double)pix, 0.0, false, frame);
     }
 
-    void SetPixelHelper(uint32_t index, uint32_t x, uint32_t y, double pix,
+    void SetPixelHelper(uint32_t index, uint32_t x, uint32_t y, double pix, double time,
                         bool pivot, uint32_t frame);
-    void PushPixelHelper(uint32_t x, uint32_t y, double pix, bool pivot,
+    void PushPixelHelper(uint32_t x, uint32_t y, double pix, double time, bool pivot,
                          uint32_t frame);
     double GetPixel(uint32_t index, uint32_t frame) const;
     double GetPixel(uint32_t index) const;
@@ -64,6 +70,8 @@ namespace eudaq {
     double GetX(uint32_t index) const;
     double GetY(uint32_t index, uint32_t frame) const;
     double GetY(uint32_t index) const;
+    double GetTimestamp(uint32_t index, uint32_t frame) const;
+    double GetTimestamp(uint32_t index) const;
     bool GetPivot(uint32_t index, uint32_t frame = 0) const;
     void SetPivot(uint32_t index, uint32_t frame, bool PivotFlag);
     // defined for short, int, double
@@ -98,6 +106,7 @@ namespace eudaq {
     uint32_t HitPixels() const;
     uint32_t PivotPixel() const;
 
+
     int GetFlags(int f) const;
     bool NeedsCDS() const;
     int  Polarity() const;
@@ -116,16 +125,20 @@ namespace eudaq {
     uint32_t m_ysize;
     uint32_t m_flags;
     uint32_t m_pivotpixel;
+    double m_timestamp{};
     std::vector<std::vector<pixel_t>> m_pix;
     std::vector<std::vector<coord_t>> m_x, m_y;
+    std::vector<std::vector<double>> m_time;
     std::vector<std::vector<bool>> m_pivot;
     std::vector<uint32_t> m_mat;
 
     mutable const std::vector<pixel_t> *m_result_pix;
     mutable const std::vector<coord_t> *m_result_x, *m_result_y;
+    mutable const std::vector<double> *m_result_time;
 
     mutable std::vector<pixel_t> m_temp_pix;
     mutable std::vector<coord_t> m_temp_x, m_temp_y;
+    mutable std::vector<double> m_temp_time;
   };
 
 } // namespace eudaq

--- a/main/lib/core/include/eudaq/StandardPlane.hh
+++ b/main/lib/core/include/eudaq/StandardPlane.hh
@@ -37,32 +37,32 @@ namespace eudaq {
     template <typename T>
       void SetPixel(uint32_t index, uint32_t x, uint32_t y, T pix,
 		    bool pivot = false, uint32_t frame = 0) {
-      SetPixelHelper(index, x, y, (double)pix, 0.0, pivot, frame);
+      SetPixelHelper(index, x, y, (double)pix, 0, pivot, frame);
     }
     template <typename T>
-      void SetPixel(uint32_t index, uint32_t x, uint32_t y, T pix, double time,
+      void SetPixel(uint32_t index, uint32_t x, uint32_t y, T pix, uint64_t time_ps,
 		    bool pivot = false, uint32_t frame = 0) {
-      SetPixelHelper(index, x, y, (double)pix, time, pivot, frame);
+      SetPixelHelper(index, x, y, (double)pix, time_ps, pivot, frame);
     }
 
     template <typename T>
       void SetPixel(uint32_t index, uint32_t x, uint32_t y, T pix,
 		    uint32_t frame) {
-      SetPixelHelper(index, x, y, (double)pix, 0.0, false, frame);
+      SetPixelHelper(index, x, y, (double)pix, 0, false, frame);
     }
     template <typename T>
-      void PushPixel(uint32_t x, uint32_t y, T pix, double time = 0.0, bool pivot = false,
+      void PushPixel(uint32_t x, uint32_t y, T pix, uint64_t time_ps = 0, bool pivot = false,
 		     uint32_t frame = 0) {
-      PushPixelHelper(x, y, (double)pix, time, pivot, frame);
+      PushPixelHelper(x, y, (double)pix, time_ps, pivot, frame);
     }
     template <typename T>
       void PushPixel(uint32_t x, uint32_t y, T pix, uint32_t frame) {
-      PushPixelHelper(x, y, (double)pix, 0.0, false, frame);
+      PushPixelHelper(x, y, (double)pix, 0, false, frame);
     }
 
-    void SetPixelHelper(uint32_t index, uint32_t x, uint32_t y, double pix, double time,
+    void SetPixelHelper(uint32_t index, uint32_t x, uint32_t y, double pix, uint64_t time_ps,
                         bool pivot, uint32_t frame);
-    void PushPixelHelper(uint32_t x, uint32_t y, double pix, double time, bool pivot,
+    void PushPixelHelper(uint32_t x, uint32_t y, double pix, double time_ps, bool pivot,
                          uint32_t frame);
     double GetPixel(uint32_t index, uint32_t frame) const;
     double GetPixel(uint32_t index) const;
@@ -70,8 +70,12 @@ namespace eudaq {
     double GetX(uint32_t index) const;
     double GetY(uint32_t index, uint32_t frame) const;
     double GetY(uint32_t index) const;
-    double GetTimestamp(uint32_t index, uint32_t frame) const;
-    double GetTimestamp(uint32_t index) const;
+
+    // NOTE this returns a timestamp in picoseconds
+    uint64_t GetTimestamp(uint32_t index, uint32_t frame) const;
+    // NOTE this returns a timestamp in picoseconds
+    uint64_t GetTimestamp(uint32_t index) const;
+
     bool GetPivot(uint32_t index, uint32_t frame = 0) const;
     void SetPivot(uint32_t index, uint32_t frame, bool PivotFlag);
     // defined for short, int, double
@@ -125,20 +129,22 @@ namespace eudaq {
     uint32_t m_ysize;
     uint32_t m_flags;
     uint32_t m_pivotpixel;
-    double m_timestamp{};
+
+    // Timestamp of this plane in picoseconds
+    uint64_t m_timestamp{};
     std::vector<std::vector<pixel_t>> m_pix;
     std::vector<std::vector<coord_t>> m_x, m_y;
-    std::vector<std::vector<double>> m_time;
+    std::vector<std::vector<uint64_t>> m_time;
     std::vector<std::vector<bool>> m_pivot;
     std::vector<uint32_t> m_mat;
 
     mutable const std::vector<pixel_t> *m_result_pix;
     mutable const std::vector<coord_t> *m_result_x, *m_result_y;
-    mutable const std::vector<double> *m_result_time;
+    mutable const std::vector<uint64_t> *m_result_time;
 
     mutable std::vector<pixel_t> m_temp_pix;
     mutable std::vector<coord_t> m_temp_x, m_temp_y;
-    mutable std::vector<double> m_temp_time;
+    mutable std::vector<uint64_t> m_temp_time;
   };
 
 } // namespace eudaq

--- a/main/lib/core/src/StandardEvent.cc
+++ b/main/lib/core/src/StandardEvent.cc
@@ -55,11 +55,11 @@ namespace eudaq {
     return m_planes[i];
   }
 
-  double StandardEvent::GetTimeBegin() const {
+  uint64_t StandardEvent::GetTimeBegin() const {
     return time_begin;
   }
 
-  double StandardEvent::GetTimeEnd() const {
+  uint64_t StandardEvent::GetTimeEnd() const {
     return time_end;
   }
 

--- a/main/lib/core/src/StandardEvent.cc
+++ b/main/lib/core/src/StandardEvent.cc
@@ -15,18 +15,22 @@ namespace eudaq {
     auto ev = Factory<Event>::MakeShared(m_id_factory);
     return std::dynamic_pointer_cast<StandardEvent>(ev);
   }
-  
+
   StandardEvent::StandardEvent(){
     SetType(m_id_factory);
   }
-  
+
   StandardEvent::StandardEvent(Deserializer &ds) : Event(ds) {
     ds.read(m_planes);
+    ds.read(time_begin);
+    ds.read(time_end);
   }
 
   void StandardEvent::Serialize(Serializer &ser) const {
     Event::Serialize(ser);
     ser.write(m_planes);
+    ser.write(time_begin);
+    ser.write(time_end);
   }
 
   void StandardEvent::Print(std::ostream & os, size_t offset) const{
@@ -42,7 +46,7 @@ namespace eudaq {
     Event::Print(os,offset+2);
     os << std::string(offset, ' ') << "</StandardEvent>\n";
   }
-  
+
   size_t StandardEvent::NumPlanes() const { return m_planes.size(); }
 
   StandardPlane &StandardEvent::GetPlane(size_t i) { return m_planes[i]; }

--- a/main/lib/core/src/StandardEvent.cc
+++ b/main/lib/core/src/StandardEvent.cc
@@ -55,6 +55,14 @@ namespace eudaq {
     return m_planes[i];
   }
 
+  double StandardEvent::GetTimeBegin() const {
+    return time_begin;
+  }
+
+  double StandardEvent::GetTimeEnd() const {
+    return time_end;
+  }
+
   StandardPlane &StandardEvent::AddPlane(const StandardPlane &plane) {
     m_planes.push_back(plane);
     return m_planes.back();

--- a/main/lib/core/src/StandardPlane.cc
+++ b/main/lib/core/src/StandardPlane.cc
@@ -86,14 +86,14 @@ namespace eudaq{
     }
   }
 
-  void StandardPlane::PushPixelHelper(uint32_t x, uint32_t y, double p, double time,
+  void StandardPlane::PushPixelHelper(uint32_t x, uint32_t y, double p, uin64_t time_ps,
 				      bool pivot, uint32_t frame) {
     if (frame > m_x.size())
       EUDAQ_THROW("Bad frame number " + to_string(frame) + " in PushPixel");
     m_x[frame].push_back(x);
     m_y[frame].push_back(y);
     m_pix[frame].push_back(p);
-    m_time[frame].push_back(time);
+    m_time[frame].push_back(time_ps);
     if (m_pivot.size())
       m_pivot[frame].push_back(pivot);
     // std::cout << "DBG: " << frame << ", " << x << ", " << y << ", " << p <<
@@ -101,7 +101,7 @@ namespace eudaq{
   }
 
   void StandardPlane::SetPixelHelper(uint32_t index, uint32_t x, uint32_t y,
-				     double pix, double time, bool pivot, uint32_t frame) {
+				     double pix, uint64_t time_ps, bool pivot, uint32_t frame) {
     if (frame >= m_pix.size())
       EUDAQ_THROW("Bad frame number " + to_string(frame) + " in SetPixel");
     if (frame < m_x.size()) {
@@ -117,7 +117,7 @@ namespace eudaq{
       m_pix.at(frame).at(index) = pix;
     }
     if (frame < m_time.size()) {
-      m_time.at(frame).at(index) = time;
+      m_time.at(frame).at(index) = time_ps;
     }
   }
 
@@ -130,10 +130,10 @@ namespace eudaq{
     SetupResult();
     return m_result_pix->at(index);
   }
-  double StandardPlane::GetTimestamp(uint32_t index, uint32_t frame) const {
+  uint64_t StandardPlane::GetTimestamp(uint32_t index, uint32_t frame) const {
     return m_time.at(frame).at(index);
   }
-  double StandardPlane::GetTimestamp(uint32_t index) const {
+  uint64_t StandardPlane::GetTimestamp(uint32_t index) const {
     SetupResult();
     return m_result_time->at(index);
   }

--- a/main/lib/core/src/StandardPlane.cc
+++ b/main/lib/core/src/StandardPlane.cc
@@ -86,7 +86,7 @@ namespace eudaq{
     }
   }
 
-  void StandardPlane::PushPixelHelper(uint32_t x, uint32_t y, double p, uin64_t time_ps,
+  void StandardPlane::PushPixelHelper(uint32_t x, uint32_t y, double p, uint64_t time_ps,
 				      bool pivot, uint32_t frame) {
     if (frame > m_x.size())
       EUDAQ_THROW("Bad frame number " + to_string(frame) + " in PushPixel");

--- a/main/lib/core/src/StandardPlane.cc
+++ b/main/lib/core/src/StandardPlane.cc
@@ -68,6 +68,7 @@ namespace eudaq{
     m_xsize = w;
     m_ysize = h;
     m_pix.resize(frames);
+    m_time.resize(frames);
     m_x.resize(GetFlags(FLAG_DIFFCOORDS) ? frames : 1);
     m_y.resize(GetFlags(FLAG_DIFFCOORDS) ? frames : 1);
     m_pivot.resize(GetFlags(FLAG_WITHPIVOT)
@@ -75,6 +76,7 @@ namespace eudaq{
 		   : 0);
     for (size_t i = 0; i < frames; ++i) {
       m_pix[i].resize(npix);
+      m_time[i].resize(npix);
     }
     for (size_t i = 0; i < m_x.size(); ++i) {
       m_x[i].resize(npix);

--- a/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
+++ b/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
@@ -10,7 +10,7 @@ public:
 namespace{
   auto dummy0 = eudaq::Factory<eudaq::StdEventConverter>::
     Register<TluRawEvent2StdEventConverter>(TluRawEvent2StdEventConverter::m_id_factory);
-} 
+}
 
 bool TluRawEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::StandardEventSP d2, eudaq::ConfigurationSPC conf) const{
   if(!d2->IsFlagPacket()){
@@ -29,5 +29,9 @@ bool TluRawEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Standa
     d2->SetTag(TLU+stm+"_TSE", std::to_string(d1->GetTimestampEnd()));
     d2->SetTag(TLU+stm+"_TRG", std::to_string(d1->GetTriggerN()));
   }
+
+  // Set times for StdEvent in picoseconds (timestamps provided in nanoseconds):
+  d2->SetTimeBegin(static_cast<uint64_t>(d1->GetTimestampBegin()) * 1000);
+  d2->SetTimeEnd(static_cast<uint64_t>(d1->GetTimestampEnd()) * 1000);
   return true;
 }


### PR DESCRIPTION
This PR extends the `StandardPlane` and `StandardEvent` classes by the possibility of storing timestamps. This is required for AIDA devices when using the EUDAQ-internal Raw->StdEvent conversions on the offline analysis.

IMHO the `StandardPlane` class should be completely rewritten, but that's a different story.