### PR TITLE
Correctly propagate the result of event decoding

### DIFF
--- a/main/lib/core/src/RawEvent2StdEventConverter.cc
+++ b/main/lib/core/src/RawEvent2StdEventConverter.cc
@@ -24,8 +24,7 @@ namespace eudaq{
     uint32_t id = ev->GetExtendWord();
     auto cvt = Factory<StdEventConverter>::MakeUnique(id);
     if(cvt){
-      cvt->Converting(d1, d2, conf);
-      return true;
+      return cvt->Converting(d1, d2, conf);
     }
     else{
       EUDAQ_WARN("WARNING, no StdEventConverter for RawEvent with ExtendWord("


### PR DESCRIPTION
Right now, event converter cannot properly fail because the returned `false` boolean from the event converter is not propagated by the `RawEvent2StdEventConverter` class.

This PR fixes that.