### PR TITLE
added disconnect option for all producers

### DIFF
--- a/main/lib/core/include/eudaq/CommandReceiver.hh
+++ b/main/lib/core/include/eudaq/CommandReceiver.hh
@@ -36,7 +36,7 @@ namespace eudaq {
     virtual void OnUnrecognised(const std::string &cmd, const std::string &argv);
     virtual void RunLoop();
     std::string Connect();
-    
+    void Disconnect();
     void SendStatus();
     void SetStatus(Status::State, const std::string&);
     void SetStatusMsg(const std::string&);

--- a/main/lib/core/src/CommandReceiver.cc
+++ b/main/lib/core/src/CommandReceiver.cc
@@ -369,6 +369,10 @@ namespace eudaq {
     return m_addr_client;
   }
 
+  void CommandReceiver::Disconnect(){
+    m_is_destructing = true;
+    OnTerminate();
+  }
   bool CommandReceiver::Deamon(){
     while(!m_is_destructing){
       std::this_thread::sleep_for(std::chrono::milliseconds(200));


### PR DESCRIPTION
This PR adds a function called `Disconnect()` to the CommandReceiver, which allows a producer to disconnect from the RunControl, also freeing the connection. 
@eyiliu implemented everything required to do so. I only had to create the function.