### PR TITLE
fixed bug in I2C, that causes TLU not to scan I2C bus

### DIFF
--- a/user/tlu/hardware/src/AidaTluController.cc
+++ b/user/tlu/hardware/src/AidaTluController.cc
@@ -391,6 +391,7 @@ namespace tlu {
       }else{
       std::cout << "\tSuccess." << std::endl;
     }
+    return 1;
   }
 
   int AidaTluController::InitializeClkChip(const std::string & filename, uint8_t verbose){


### PR DESCRIPTION
The AIDATluConteroller has the function `uint32_t AidaTluController::I2C_enable(char EnclustraExpAddr)` without a return value, which causes the AIDATLUProducer to crash on my machines - added a return 1 at the end to fix this. The return value is not used in the code and it might be a good idea to fix that properly. 
