### PR TITLE
StandardEvent: initialize event start/end with zero

### DIFF
--- a/main/lib/core/include/eudaq/StandardEvent.hh
+++ b/main/lib/core/include/eudaq/StandardEvent.hh
@@ -58,7 +58,7 @@ namespace eudaq {
 
   private:
     std::vector<StandardPlane> m_planes;
-    uint64_t time_begin, time_end;
+    uint64_t time_begin{0}, time_end{0};
   };
 
   inline std::ostream &operator<<(std::ostream &os, const StandardPlane &pl) {


### PR DESCRIPTION
We need to initialize event start and end timestamps to zero, otherwise they might contain random memory content.