### PR TITLE
fixed bug in I2C, that causes TLU not to scan I2C bus

### DIFF
--- a/user/tlu/hardware/src/AidaTluController.cc
+++ b/user/tlu/hardware/src/AidaTluController.cc
@@ -391,6 +391,7 @@ namespace tlu {
       }else{
       std::cout << "\tSuccess." << std::endl;
     }
+    return 1;
   }
 
   int AidaTluController::InitializeClkChip(const std::string & filename, uint8_t verbose){


### PR DESCRIPTION
Rather long-standing bug, that causes AIDA-TLU to crash on some systems as `uint32_t AidaTluController::I2C_enable(char EnclustraExpAddr)` has not been returning anything.