### PR TITLE
Allow retrieval of detector type from StdEvent

### DIFF
--- a/main/lib/core/include/eudaq/StandardEvent.hh
+++ b/main/lib/core/include/eudaq/StandardEvent.hh
@@ -18,7 +18,7 @@ namespace eudaq {
   using StandardEventSPC = StdEventSPC;
 
   class DLLEXPORT StandardEvent : public Event {
-    public:
+  public:
     StandardEvent();
     StandardEvent(Deserializer &);
 
@@ -56,9 +56,24 @@ namespace eudaq {
     static StdEventSP MakeShared();
     static const uint32_t m_id_factory = cstr2hash("StandardEvent");
 
+    /**
+     * @brief Get detectpr type for this event
+     * @return Human-readable detector type as string
+     */
+    std::string GetDetectorType() {
+      return detector_type;
+    }
+
+    /**
+     * @brief Set detector type for this event
+     * @param type Human-readable detector type
+     */
+    void SetDetectorType(std::string type) { detector_type = type; }
+
   private:
     std::vector<StandardPlane> m_planes;
     uint64_t time_begin{0}, time_end{0};
+    std::string detector_type;
   };
 
   inline std::ostream &operator<<(std::ostream &os, const StandardPlane &pl) {

--- a/user/caribou/module/src/ATLASPixEventConverter.cc
+++ b/user/caribou/module/src/ATLASPixEventConverter.cc
@@ -101,7 +101,8 @@ bool ATLASPixEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Stan
     d2->SetTimeBegin(timestamp * 1000);
     d2->SetTimeEnd(timestamp * 1000);
 
-
+    // Identify the detetor type
+    d2->SetDetectorType("ATLASPix");
     return true;
   } else {
     // data is not hit information

--- a/user/caribou/module/src/CLICpix2EventConverter.cc
+++ b/user/caribou/module/src/CLICpix2EventConverter.cc
@@ -206,6 +206,8 @@ bool CLICpix2Event2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Stan
   d2->SetTimeBegin(shutter_open * 1000);
   d2->SetTimeEnd(shutter_close * 1000);
 
+  // Identify the detetor type
+  d2->SetDetectorType("CLICpix2");
   // Indicate that data was successfully converted
   return true;
 }

--- a/user/eudet/module/src/NiRawEvent2StdEventConverter.cc
+++ b/user/eudet/module/src/NiRawEvent2StdEventConverter.cc
@@ -27,6 +27,9 @@ bool NiRawEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Standar
   if(!ev)
     return false;
 
+    // Identify the detetor type
+  d2->SetDetectorType("MIMIOSA26");
+
   if(!d2->IsFlagPacket()){
     d2->SetFlag(d1->GetFlag());
     d2->SetRunN(d1->GetRunN());

--- a/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
+++ b/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
@@ -176,5 +176,8 @@ bool Timepix3RawEvent2StdEventConverter::Converting(eudaq::EventSPC ev, eudaq::S
   d2->SetTimeBegin(event_begin);
   d2->SetTimeEnd(event_end);
 
+  // Identify the detetor type
+  d2->SetDetectorType("Timepix3");
+
   return data_found;
 }

--- a/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
+++ b/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
@@ -33,5 +33,8 @@ bool TluRawEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Standa
   // Set times for StdEvent in picoseconds (timestamps provided in nanoseconds):
   d2->SetTimeBegin(d1->GetTimestampBegin() * 1000);
   d2->SetTimeEnd(d1->GetTimestampEnd() * 1000);
+
+  // Identify the detetor type
+  d2->SetDetectorType("TLU");
   return true;
 }


### PR DESCRIPTION
This is a PR intended to solve the issue raised in #576 

It adds a new member plus setter/getter to StdEvent to store the detector type. It has to be set explicitly by the StdEventConverter of the respective detector.