### PR TITLE
Bugfix in the StdEvent

### DIFF
--- a/user/eudet/module/src/NiRawEvent2StdEventConverter.cc
+++ b/user/eudet/module/src/NiRawEvent2StdEventConverter.cc
@@ -148,7 +148,7 @@ void NiRawEvent2StdEventConverter::DecodeFrame(eudaq::StandardPlane& plane, cons
       uint16_t column = v >> 2 & 0x7ff;
       uint16_t num = v & 3;
       for (uint16_t j = 0; j < num + 1; ++j) {
-	plane.PushPixel(column + j, row, 1, pivot, fm_n);
+        plane.PushPixel(column + j, row, 1,0, pivot, fm_n);
       }
     }
   }


### PR DESCRIPTION
Digging into the issue #592 I found a bug in the NiRawDataConversion and the StandardEvent. The issue is present since the merge of PR #532. Fortunately, it is not affecting the pixel addresses, only the timestamps are wrongly/randomly assigned.
It would be nice if @mwilliams294 could test if her issues are fixed.  