### PR TITLE
Fix Installation of Target Files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,10 +160,12 @@ install(EXPORT eudaqTargets
   DESTINATION ${PROJECT_BINARY_DIR}
   COMPONENT dev)
 
+file(GLOB TARGET_FILES "${PROJECT_BINARY_DIR}/eudaqTarget*.cmake")
+
 install(FILES
   "${PROJECT_BINARY_DIR}/eudaqConfig.cmake"
   "${PROJECT_BINARY_DIR}/eudaqConfigVersion.cmake"
-  "${PROJECT_BINARY_DIR}/eudaqTargets.cmake"
+  ${TARGET_FILES}
   DESTINATION ${EUDAQ_CMAKE_DIR}
   COMPONENT dev)
 


### PR DESCRIPTION
Commit 526a258420b93534898db235d5b283cbbc0bed61 resulted in only `eudaqTargets.cmake` being copied to the install location, while `eudaqTargets-<BUILD_FLAVOR>.cmake` have been left behind. They are required because they contain the `IMPORTED_LOCATION` statement used to locate the libraries at link time.