### PR TITLE
ROOT monitor example

### DIFF
--- a/monitors/rootmonitor/CMakeLists.txt
+++ b/monitors/rootmonitor/CMakeLists.txt
@@ -1,3 +1,5 @@
+find_package(ROOT QUIET)
+
 cmake_dependent_option(EUDAQ_BUILD_ONLINE_ROOT_MONITOR "monitor/ROOTMonitor executable (requires ROOT)" OFF
   "ROOT_FOUND" OFF)
 

--- a/monitors/rootmonitor/include/eudaq/ROOTMonitorWindow.hh
+++ b/monitors/rootmonitor/include/eudaq/ROOTMonitorWindow.hh
@@ -127,7 +127,7 @@ namespace eudaq{
 
     const TGPicture* m_icon_summ;
     const TGPicture* m_icon_save, *m_icon_del, *m_icon_open;
-    const TGPicture* m_icon_th1, *m_icon_th2, *m_icon_tgraph, *m_icon_track;
+    const TGPicture* m_icon_th1, *m_icon_th2, *m_icon_tprofile, *m_icon_track;
 
     /// Timer for auto-refresh loop
     std::unique_ptr<TTimer> m_timer;
@@ -152,7 +152,8 @@ namespace eudaq{
     std::map<std::string, const TGPicture*> m_obj_icon = {
       {"TH1", m_icon_th1}, {"TH1F", m_icon_th1}, {"TH1D", m_icon_th1}, {"TH1I", m_icon_th1},
       {"TH2", m_icon_th2}, {"TH2F", m_icon_th2}, {"TH2D", m_icon_th2}, {"TH2I", m_icon_th2},
-      {"TGraph", m_icon_tgraph}, {"TMultiGraph", m_icon_track}
+      {"TGraph", m_icon_tprofile}, {"TGraph2D", m_icon_th2},
+      {"TProfile", m_icon_tprofile}, {"TMultiGraph", m_icon_track}
     };
     /// List of all objects to be drawn on main canvas
     std::vector<MonitoredObject*> m_drawable;

--- a/monitors/rootmonitor/src/ROOTMonitorWindow.cc
+++ b/monitors/rootmonitor/src/ROOTMonitorWindow.cc
@@ -9,6 +9,7 @@
 
 // required for object-specific "clear"
 #include "TGraph.h"
+#include "TGraph2D.h"
 #include "TH1.h"
 #include "TH2.h"
 #include "TMultiGraph.h"
@@ -25,7 +26,7 @@ namespace eudaq {
      m_icon_open(gClient->GetPicture("bld_open.xpm")),
      m_icon_th1(gClient->GetPicture("h1_t.xpm")),
      m_icon_th2(gClient->GetPicture("h2_t.xpm")),
-     m_icon_tgraph(gClient->GetPicture("profile_t.xpm")),
+     m_icon_tprofile(gClient->GetPicture("profile_t.xpm")),
      m_icon_track(gClient->GetPicture("eve_track.xpm")),
      m_icon_summ(gClient->GetPicture("draw_t.xpm")),
      m_timer(new TTimer(1000, kTRUE)){
@@ -115,7 +116,7 @@ namespace eudaq {
     gClient->FreePicture(m_icon_del);
     gClient->FreePicture(m_icon_th1);
     gClient->FreePicture(m_icon_th2);
-    gClient->FreePicture(m_icon_tgraph);
+    gClient->FreePicture(m_icon_tprofile);
     gClient->FreePicture(m_icon_track);
     gClient->FreePicture(m_icon_summ);
     for (auto& obj : m_objects)
@@ -408,6 +409,8 @@ namespace eudaq {
     }
     else if (obj->InheritsFrom("TGraph"))
       dynamic_cast<TGraph*>(obj)->Set(0);
+    else if (obj->InheritsFrom("TGraph2D"))
+      dynamic_cast<TGraph2D*>(obj)->Set(0);
     else if (obj->InheritsFrom("TH1"))
       dynamic_cast<TH1*>(obj)->Reset();
     else

--- a/user/example/module/CMakeLists.txt
+++ b/user/example/module/CMakeLists.txt
@@ -4,9 +4,12 @@ aux_source_directory(src MODULE_SRC)
 if(NOT EUDAQ_TTREE_LIBRARY)
   list(REMOVE_ITEM MODULE_SRC src/Ex0RawEvent2TTreeEventConverter.cc)
 endif()
+if(NOT EUDAQ_ROOT_MONITOR_LIBRARY)
+  list(REMOVE_ITEM MODULE_SRC src/Ex0ROOTMonitor.cc)
+endif()
 
 add_library(${EUDAQ_MODULE} SHARED ${MODULE_SRC})
-target_link_libraries(${EUDAQ_MODULE} ${EUDAQ_CORE_LIBRARY} ${EUDAQ_TTREE_LIBRARY})
+target_link_libraries(${EUDAQ_MODULE} ${EUDAQ_CORE_LIBRARY} ${EUDAQ_TTREE_LIBRARY} ${EUDAQ_ROOT_MONITOR_LIBRARY})
 
 install(TARGETS
   ${EUDAQ_MODULE}

--- a/user/example/module/src/Ex0ROOTMonitor.cc
+++ b/user/example/module/src/Ex0ROOTMonitor.cc
@@ -36,12 +36,12 @@ namespace{
 }
 
 void Ex0ROOTMonitor::AtConfiguration(){
-  m_my_hist = m_monitor->Book<TH1D>("my_hist", "Example histogram",
+  m_my_hist = m_monitor->Book<TH1D>("Channel 0/my_hist", "Example histogram",
     "h_example", "A histogram;x-axis title;y-axis title", 100, 0., 1.);
-  m_my_graph = m_monitor->Book<TGraph2D>("my_graph", "Example graph");
+  m_my_graph = m_monitor->Book<TGraph2D>("Channel 0/my_graph", "Example graph");
   m_my_graph->SetTitle("A graph;x-axis title;y-axis title;z-axis title");
   m_monitor->SetDrawOptions(m_my_graph, "colz");
-  m_my_prof = m_monitor->Book<TProfile>("my_profile", "Example profile",
+  m_my_prof = m_monitor->Book<TProfile>("Channel 0/my_profile", "Example profile",
     "p_example", "A profile histogram;x-axis title;y-axis title", 100, 0., 1.);
   m_my_prof->SetTitle("A graph;x-axis title;y-axis title;z-axis title");
 }

--- a/user/example/module/src/Ex0ROOTMonitor.cc
+++ b/user/example/module/src/Ex0ROOTMonitor.cc
@@ -43,7 +43,6 @@ void Ex0ROOTMonitor::AtConfiguration(){
   m_monitor->SetDrawOptions(m_my_graph, "colz");
   m_my_prof = m_monitor->Book<TProfile>("Channel 0/my_profile", "Example profile",
     "p_example", "A profile histogram;x-axis title;y-axis title", 100, 0., 1.);
-  m_my_prof->SetTitle("A graph;x-axis title;y-axis title;z-axis title");
 }
 
 void Ex0ROOTMonitor::AtEventReception(eudaq::EventSP ev){

--- a/user/example/module/src/Ex0ROOTMonitor.cc
+++ b/user/example/module/src/Ex0ROOTMonitor.cc
@@ -1,0 +1,56 @@
+#include "eudaq/ROOTMonitor.hh"
+
+#include "TH1.h"
+#include "TGraph2D.h"
+#include "TProfile.h"
+
+// let there be a user-defined Ex0EventDataFormat, containing e.g. three
+// double-precision attributes get'ters:
+//   double GetQuantityX(), double GetQuantityY(), and double GetQuantityZ()
+struct Ex0EventDataFormat {
+  Ex0EventDataFormat(const eudaq::Event&) {}
+  double GetQuantityX() const { return (double)rand()/RAND_MAX; }
+  double GetQuantityY() const { return (double)rand()/RAND_MAX; }
+  double GetQuantityZ() const { return (double)rand()/RAND_MAX; }
+};
+
+class Ex0ROOTMonitor : public eudaq::ROOTMonitor {
+public:
+  Ex0ROOTMonitor(const std::string& name, const std::string& runcontrol):
+    eudaq::ROOTMonitor(name, "Ex0 ROOT monitor", runcontrol){}
+
+  void AtConfiguration() override;
+  void AtEventReception(eudaq::EventSP ev) override;
+
+  static const uint32_t m_id_factory = eudaq::cstr2hash("Ex0ROOTMonitor");
+
+private:
+  TH1D* m_my_hist;
+  TGraph2D* m_my_graph;
+  TProfile* m_my_prof;
+};
+
+namespace{
+  auto mon_rootmon = eudaq::Factory<eudaq::Monitor>::
+    Register<Ex0ROOTMonitor, const std::string&, const std::string&>(Ex0ROOTMonitor::m_id_factory);
+}
+
+void Ex0ROOTMonitor::AtConfiguration(){
+  m_my_hist = m_monitor->Book<TH1D>("my_hist", "Example histogram",
+    "h_example", "A histogram;x-axis title;y-axis title", 100, 0., 1.);
+  m_my_graph = m_monitor->Book<TGraph2D>("my_graph", "Example graph");
+  m_my_graph->SetTitle("A graph;x-axis title;y-axis title;z-axis title");
+  m_monitor->SetDrawOptions(m_my_graph, "colz");
+  m_my_prof = m_monitor->Book<TProfile>("my_profile", "Example profile",
+    "p_example", "A profile histogram;x-axis title;y-axis title", 100, 0., 1.);
+  m_my_prof->SetTitle("A graph;x-axis title;y-axis title;z-axis title");
+}
+
+void Ex0ROOTMonitor::AtEventReception(eudaq::EventSP ev){
+  auto event = std::make_shared<Ex0EventDataFormat>(*ev);
+  m_my_hist->Fill(event->GetQuantityX());
+  m_my_graph->SetPoint(m_my_graph->GetN(),
+    event->GetQuantityX(), event->GetQuantityY(), event->GetQuantityZ());
+  m_my_prof->Fill(event->GetQuantityX(), event->GetQuantityY());
+}
+


### PR DESCRIPTION
An example of a ROOT monitor is introduced in the `user/example` sub-package.
Additionally, the `TGraph2D`-specific procedure has been implemented in the `ROOTMonitorWindow` clearing method.

A follow-up PR will propose additions in the users' manual for the documentation of this ROOT monitor.