### PR TITLE
FIX: Path to README.md travix badge. Update Windows version requireme…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 EUDAQ version 1
 =======
 
-[![Build Status](https://travis-ci.org/eudaq/eudaq.svg?branch=v1.x-dev)](https://travis-ci.org/eudaq/eudaq) 
+[![Build Status](https://travis-ci.com/eudaq/eudaq.svg?branch=v1.x-dev)](https://travis-ci.com/eudaq/eudaq) 
 [![Build status](https://ci.appveyor.com/api/projects/status/n3tq45kkupyvjihg/branch/v1.x-dev?svg=true)](https://ci.appveyor.com/project/eudaq/eudaq/branch/v1.x-dev)
 
 **Note: EUDAQ version 1.10 requires a C++14 compliant compiler.**
@@ -129,8 +129,8 @@ make install
 
 #### Visual Studio for compiling (MSVC)
 
-- The recommended windows compiler is MSVC (Microsoft Visual C++) like Visual Studio 2015 and later
-- Download Visual Studio Express Desktop (e.g. 2017 Version)
+- The recommended windows compiler is MSVC (Microsoft Visual C++) like Visual Studio 2019 and later (earlier versions up to 2015 still work but do not support ROOT6)
+- Download Visual Studio Express Desktop (e.g. 2019 Version)
 
 #### Compiling using cmake syntax
 


### PR DESCRIPTION
…nt to 2019 (adding comment about earlier versions possible but not supporting ROOT 6).