### PR TITLE
Solved error when using pedantic and overloaded-virtual flags

### DIFF
--- a/main/lib/core/include/eudaq/Factory.hh
+++ b/main/lib/core/include/eudaq/Factory.hh
@@ -61,7 +61,7 @@ namespace eudaq{
       return nullptr;
     }
     return (it->second)(std::forward<ARGS>(args)...);
-  };
+  }
 
   template <typename BASE>
   template <typename ...ARGS>
@@ -90,7 +90,7 @@ namespace eudaq{
       init=false;
     }
     return m;
-  };
+  }
     
   template <typename BASE>
   template <typename DERIVED, typename... ARGS>
@@ -105,7 +105,7 @@ namespace eudaq{
     //   std::cout<<e.first<<"  ";
     // std::cout<<std::endl;
     return reinterpret_cast<std::uintptr_t>(&ins);
-  };
+  }
 
 }
 

--- a/main/lib/core/include/eudaq/LogMessage.hh
+++ b/main/lib/core/include/eudaq/LogMessage.hh
@@ -19,7 +19,7 @@ namespace eudaq {
                const Time &t = Time::Current());
     LogMessage(Deserializer &);
     virtual void Serialize(Serializer &) const;
-    virtual void Print(std::ostream &) const;
+    virtual void Print(std::ostream &, size_t offset = 0) const override;
     void Write(std::ostream &) const;
     static LogMessage Read(std::istream &);
     LogMessage &SetLocation(const std::string &file, unsigned line,

--- a/main/lib/core/src/LogMessage.cc
+++ b/main/lib/core/src/LogMessage.cc
@@ -74,7 +74,7 @@ namespace eudaq {
     ser.write(m_time);
   }
 
-  void LogMessage::Print(std::ostream &os) const {
+  void LogMessage::Print(std::ostream &os, size_t offset) const {
       // print the time bold
 
 #ifdef _WIN32


### PR DESCRIPTION
Dear Eudaq developers,
as you may know, for the CMS Phase II SW we uses Eudaq to run at the Desy test beam.
Since last time we did a testbeam there, we raised the requirements in the C++ flags and now we are having problem in compiling the Ph2_ACF with your code.

The errors are due to the flag pedantic and overloaded-virtual
The first ones are caused by some ';' at the end of functions in Factory.hh that I removed.
The overloaded-virtual error caused is caused by "virtual void LogMessage::Print(std::ostream &) const" which hides "virtual void Status::Print(std::ostream &, size_t offset = 0) const"
I am not totally sure if the solution I propose in the PR is addressing the aim of this function, but a function name change would mean a much larger intervention that I'm not confident to do.

I would really appreciate if you can integrate these changes.

Many thanks in advance.
Cheers,
Fabio