### PR TITLE
Scanning

### DIFF
--- a/gui/src/euRun.cc
+++ b/gui/src/euRun.cc
@@ -651,6 +651,15 @@ void RunControlGUI::nextStep()
 
         std::this_thread::sleep_for(std::chrono::seconds(3));
         on_btnStart_clicked();
+
+        while(!allConnectionsInState(eudaq::Status::STATE_RUNNING)){
+            updateInfos();
+            QCoreApplication::processEvents();
+            std::this_thread::sleep_for (std::chrono::seconds(1));
+            std::cout << "Waiting until all components are running"<<std::endl;
+        }
+        std::this_thread::sleep_for (std::chrono::seconds(1));
+
         if(m_scan.scanIsTimeBased())
         {
             m_scanningTimer.start(1000*m_scan.timePerStep());

--- a/gui/src/scanHelper.cc
+++ b/gui/src/scanHelper.cc
@@ -29,9 +29,9 @@ bool Scan::setupScan(std::string globalConfFile, std::string scanConfFile) {
         if(scanConf->HasSection(std::to_string(i))) {
             scanConf->SetSection(std::to_string(i));
             bool nested     = scanConf->Get("nested",false) && m_allow_nested_scan;
-            double start    = scanConf->Get("start",-123456789);
-            double step     = scanConf->Get("step",-123456789);
-            double stop     = scanConf->Get("stop",-123456789);
+            double start    = scanConf->Get("start",-123456789.0);
+            double step     = scanConf->Get("step",-123456789.0);
+            double stop     = scanConf->Get("stop",-123456789.0);
             double defaultV = scanConf->Get("default",start);
             std::string param    = scanConf->Get("parameter","wrongPara");
             std::string name     = scanConf->Get("name","wrongPara");
@@ -40,7 +40,7 @@ bool Scan::setupScan(std::string globalConfFile, std::string scanConfFile) {
             if(!m_scan_is_time_based && Counter == "wrongPara")
                 return scanError("To run a scan based on a number of events, \"eventCounter\" needs to be specified in section"+std::to_string(i));
             if(name == "wrongPara" || param == "wrongPara"
-               || start == -123456789 || stop == -123456789 || step == -123456789)
+               || start == -123456789.0 || stop == -123456789.0 || step == -123456789.0)
                 return scanError("Scan section "+std::to_string(i)+" is incomplete -> Please check");
 
             defaultConf->SetSection("");


### PR DESCRIPTION
Attempt to solve two issues in the scan algorithm:

1. Runs can fail when the `RunControl` checks for the stop conditions before the producer used for event counting hasn't yet reset its event counter. Example: Usage of the TLU as event counter. Run is started, but TLU didn't react yet. Then the event count is still above the maximum number - the TLU (and others) are called to stop the run and the TLU goes into error state, because it's not yet running. Fixed by checking whether all producers are running before. Suggested by @lhuth .
2. The `start`, `stop` and `step` values are integer values casted to doubles, since the default value is an integer. I changed those to doubles to actually get floating point numbers out.