### PR TITLE
compatibility for ROOT v6-22-02

### DIFF
--- a/monitors/rootmonitor/src/ROOTMonitorWindow.cc
+++ b/monitors/rootmonitor/src/ROOTMonitorWindow.cc
@@ -6,6 +6,7 @@
 #include "TGFileDialog.h"
 #include "TCanvas.h"
 #include "TKey.h"
+#include "TObjString.h"
 
 // required for object-specific "clear"
 #include "TGraph.h"


### PR DESCRIPTION
In order to compile with ROOT v6-22-02, a missing `#include` statement was added.