### PR TITLE
TLU converter: do not presume that we have a config object

### DIFF
--- a/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
+++ b/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
@@ -37,13 +37,17 @@ bool TluRawEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Standa
   uint32_t finets4;
   uint32_t finets5;
 
-  uint8_t triggerMask = conf->Get("trigger_mask", 0x3F);
-  uint32_t delay_scint0 = conf->Get("delay_scint0", 0); // in 781.25ps bins
-  uint32_t delay_scint1 = conf->Get("delay_scint1", 0); // in 781.25ps bins
-  uint32_t delay_scint2 = conf->Get("delay_scint2", 0); // in 781.25ps bins
-  uint32_t delay_scint3 = conf->Get("delay_scint3", 0); // in 781.25ps bins
-  uint32_t delay_scint4 = conf->Get("delay_scint4", 0); // in 781.25ps bins
-  uint32_t delay_scint5 = conf->Get("delay_scint5", 0); // in 781.25ps bins
+  uint8_t triggerMask{0x3F};
+  uint32_t delay_scint0{0}, delay_scint1{0}, delay_scint2{0}, delay_scint3{0}, delay_scint4{0}, delay_scint5{0};
+  if(conf != nullptr) {
+      triggerMask = conf->Get("trigger_mask", 0x3F);
+      delay_scint0 = conf->Get("delay_scint0", 0); // in 781.25ps bins
+      delay_scint1 = conf->Get("delay_scint1", 0); // in 781.25ps bins
+      delay_scint2 = conf->Get("delay_scint2", 0); // in 781.25ps bins
+      delay_scint3 = conf->Get("delay_scint3", 0); // in 781.25ps bins
+      delay_scint4 = conf->Get("delay_scint4", 0); // in 781.25ps bins
+      delay_scint5 = conf->Get("delay_scint5", 0); // in 781.25ps bins
+  }
 
   // try/catch for std::stoi()
   try {


### PR DESCRIPTION
StdEventMonitor does not provide a `EudaqConfigSPC` object but a `nullptr` which crashes the converter unless we account for it.

@jekroege @lhuth 