### PR TITLE
Always update the config beofre sending it

### DIFF
--- a/gui/src/euRun.cc
+++ b/gui/src/euRun.cc
@@ -349,8 +349,8 @@ void RunControlGUI::onCustomContextMenu(const QPoint &point)
     QModelIndex index = viewConn->indexAt(point);
     if(index.isValid()) {
     QMenu *contextMenu = new QMenu(viewConn);
-
-    if(!m_rc->GetInitConfiguration()){
+    // load an eventually updated ini file
+    if(m_rc){
     loadInitFile();
     }
     if(m_rc->GetInitConfiguration()){
@@ -359,7 +359,8 @@ void RunControlGUI::onCustomContextMenu(const QPoint &point)
     contextMenu->addAction(initialiseAction);
     }
 
-    if(!m_rc->GetConfiguration()){
+    // load an eventually updated config file
+    if(m_rc){
     loadConfigFile();
     }
     if(m_rc->GetConfiguration()){


### PR DESCRIPTION
@simonspa  found a bug that the configuration file is not updated if a single connection is (re)-configured. This MR fixes this. Now the config/ini is automatically updated each time before it is used