### PR TITLE
class name clash for python 3.8

### DIFF
--- a/main/lib/python/src/PybindStatus.cc
+++ b/main/lib/python/src/PybindStatus.cc
@@ -3,7 +3,7 @@
 
 namespace py = pybind11;
 
-class PyStatus : public eudaq::Status {
+class PybindStatus : public eudaq::Status {
 public:
   using eudaq::Status::Status;
   void Print(std::ostream& os, size_t offset) const override {


### PR DESCRIPTION
When compiling against python 3.8, the PyStatus class in main/lib/python/src/PybindStatus.cc has a name clash with a typedef from cython, more precisely: `include/python3.8/cpython/pystate.h`

Renaming this class seems to fix it, but of course, I don't know if this breaks things down the line. Please review!
