### PR TITLE
added policy to use new cmake policy to allow overriding options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ include(CMakeDependentOption)
 if(COMMAND CMAKE_POLICY)
   if(${CMAKE_VERSION} VERSION_GREATER "3.13")
     cmake_policy(SET CMP0079 NEW) # Allow lookup of linking libraries in other directories
+    cmake_policy(SET CMP0077 NEW) # allow overwriting options with normal variables    
   endif()
 endif(COMMAND CMAKE_POLICY)
 


### PR DESCRIPTION
When adding eudaq as a submodule to other repositories, it's currently impossible to override options from master CMakeLists.txt files.
This can be fixed by requesting to explicitly use the "new" policy CMP0077.