### PR TITLE
DataCollector: always send first event to monitor

### DIFF
--- a/main/lib/core/src/DataCollector.cc
+++ b/main/lib/core/src/DataCollector.cc
@@ -204,7 +204,7 @@ namespace eudaq {
       std::unique_lock<std::mutex> lk(m_mtx_sender);
       auto senders = m_senders;
       lk.unlock();
-      if(m_evt_c%m_fraction != 0){
+      if(m_evt_c%m_fraction != 0 && m_evt_c!=1){
 	return;
       }
       for(auto &e: senders){


### PR DESCRIPTION
Found by Annika Vauth - we should *always* send the first event to the online monitor, because some detectors add vital information for decoding in the BORE tags.

It would be nicer to check for `evt->IsBORE()` but according to Annika, this flag is **never** positive in the DataCollector for some reason. :shrug: 