### PR TITLE
improved string handling

### DIFF
--- a/main/lib/core/include/eudaq/Configuration.hh
+++ b/main/lib/core/include/eudaq/Configuration.hh
@@ -58,7 +58,9 @@ namespace eudaq {
     bool SetSection(const std::string &section);
     std::string GetCurrentSectionName() const {return m_section;};
     std::string operator[](const std::string &key) const {
-      return GetString(key);
+      std::string retval;
+      if(GetString(key,retval)) return retval;
+      throw Exception("unable to find key "+key);
     }
     std::string Get(const std::string &key, const std::string &def) const;
     double Get(const std::string &key, double def) const;
@@ -91,7 +93,7 @@ namespace eudaq {
     void SetString(const std::string &key, const std::string &val);
 
   private:
-    std::string GetString(const std::string &key) const;
+    bool GetString(const std::string &key, std::string& value) const;
     typedef std::map<std::string, std::string> section_t;
     typedef std::map<std::string, section_t> map_t;
     map_t m_config;

--- a/main/lib/core/src/Configuration.cc
+++ b/main/lib/core/src/Configuration.cc
@@ -143,50 +143,44 @@ namespace eudaq {
 
   std::string Configuration::Get(const std::string &key,
                                  const std::string &def) const {
-    try {
-      return GetString(key);
-    } catch (const Exception &) {
-      // ignore: return default
-    }
-    return def;
+    std::string retval(def);
+    GetString(key,retval);
+    return retval;
   }
 
   double Configuration::Get(const std::string &key, double def) const {
-    try {
-      return from_string(GetString(key), def);
-    } catch (const Exception &) {
-      // ignore: return default
+    std::string retval;
+    if(!GetString(key,retval)){
+      return def;
+    } else {
+      return from_string(retval, def);
     }
-    return def;
   }
 
   int64_t Configuration::Get(const std::string &key, int64_t def) const {
-    try {
-      std::string s = GetString(key);
-      return std::strtoll(s.c_str(), 0, 0);
-    } catch (const Exception &) {
-      // ignore: return default
-    }
-    return def;
+    std::string retval;
+    if(!GetString(key,retval)){
+      return def;
+    } else {
+      return std::strtoll(retval.c_str(), 0, 0);
+    }    
   }
   uint64_t Configuration::Get(const std::string &key, uint64_t def) const {
-    try {
-      std::string s = GetString(key);
-      return std::strtoull(s.c_str(), 0, 0);
-    } catch (const Exception &) {
-      // ignore: return default
-    }
-    return def;
+    std::string retval;
+    if(!GetString(key,retval)){
+      return def;
+    } else {
+      return std::strtoull(retval.c_str(), 0, 0);
+    }        
   }
 
   int Configuration::Get(const std::string &key, int def) const {
-    try {
-      std::string s = GetString(key);
-      return std::strtol(s.c_str(), 0, 0);
-    } catch (const Exception &) {
-      // ignore: return default
-    }
-    return def;
+    std::string retval;
+    if(!GetString(key,retval)){
+      return def;
+    } else {
+      return std::strtol(retval.c_str(), 0, 0);
+    }            
   }
 
   void Configuration::Print(std::ostream &os, size_t offset) const {
@@ -203,12 +197,13 @@ namespace eudaq {
 
   void Configuration::Print() const { Print(std::cout); }
 
-  std::string Configuration::GetString(const std::string &key) const {
+  bool Configuration::GetString(const std::string &key, std::string& def) const {
     section_t::const_iterator i = m_cur->find(key);
     if (i != m_cur->end()) {
-      return i->second;
+      def = i->second;
+      return true;
     }
-    throw Exception("Configuration: key not found");
+    return false;
   }
 
   bool Configuration::Has(const std::string& key) const {


### PR DESCRIPTION
The current implementation of the config handler relies heavily on exceptions being thrown and caught.
This is inefficient and a pain when debugging.
This PR fixes that by switching to a non-exception way of handling configuration keys.