### PR TITLE
Added dictionaries

### DIFF
--- a/main/lib/core/CMakeLists.txt
+++ b/main/lib/core/CMakeLists.txt
@@ -7,11 +7,30 @@ set(EUDAQ_INCLUDE_DIRS
   ${CMAKE_CURRENT_LIST_DIR}/include/eudaq
   CACHE INTERNAL "directory of eudaq include")
 
+# generate the dictionary source code
+ROOT_GENERATE_DICTIONARY(eudaqCoreDict
+    include/eudaq/Exception.hh
+    LINKDEF
+    src/LinkDef.h
+    OPTIONS
+    -inlineInputHeader
+    -I${CMAKE_CURRENT_SOURCE_DIR}
+    -I${CMAKE_CURRENT_SOURCE_DIR}/src
+    MODULE
+    ${EUDAQ_CORE_LIBRARY} 
+)
+SET_SOURCE_FILES_PROPERTIES(${CMAKE_CURRENT_BINARY_DIR}/eudaqCoreDict.cxx
+  PROPERTIES
+  GENERATED TRUE
+  COMPILE_FLAGS "-Wno-unused-function -Wno-overlength-strings -Wno-zero-as-null-pointer-constant -w -I${CMAKE_CURRENT_SOURCE_DIR}"
+)    
+
+
 include_directories(include)
 include_directories(include/eudaq)
 
 aux_source_directory(src CORE_SRC)
-add_library(${EUDAQ_CORE_LIBRARY} SHARED ${CORE_SRC})
+add_library(${EUDAQ_CORE_LIBRARY} SHARED ${CORE_SRC} ${CMAKE_CURRENT_BINARY_DIR}/eudaqCoreDict.cxx)
 set_target_properties(${EUDAQ_CORE_LIBRARY} PROPERTIES DEFINE_SYMBOL "core_EXPORTS" )
 set_target_properties(${EUDAQ_CORE_LIBRARY} PROPERTIES VERSION ${EUDAQ_VERSION_MAJOR}.${EUDAQ_VERSION_MINOR})
 
@@ -20,6 +39,7 @@ if(CMAKE_COMPILER_IS_GNUCXX AND (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 5.3)
 endif()
 
 list(APPEND ADDITIONAL_LIBRARIES ${CMAKE_DL_LIBS})
+list(APPEND ADDITIONAL_LIBRARIES ${ROOT_LIBRARIES})
 target_link_libraries(${EUDAQ_CORE_LIBRARY} ${EUDAQ_THREADS_LIB} ${ADDITIONAL_LIBRARIES})
 target_include_directories(${EUDAQ_CORE_LIBRARY} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<INSTALL_INTERFACE:include>)
 

--- a/main/lib/core/CMakeLists.txt
+++ b/main/lib/core/CMakeLists.txt
@@ -51,6 +51,11 @@ install(TARGETS ${EUDAQ_CORE_LIBRARY}
   # PUBLIC_HEADER DESTINATION include/eudaq
   )
 
+# Also install the dictionary objects
+INSTALL(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/libcore_rdict.pcm
+    ${CMAKE_CURRENT_BINARY_DIR}/libcore.rootmap
+    DESTINATION lib)
 
 file(GLOB INC_FILES "${CMAKE_CURRENT_SOURCE_DIR}/include/eudaq/*.hh")
 install(FILES ${INC_FILES} DESTINATION include/eudaq)

--- a/main/lib/core/include/eudaq/Exception.hh
+++ b/main/lib/core/include/eudaq/Exception.hh
@@ -11,14 +11,14 @@
 #endif
 
 #define EUDAQ_THROWX(exc, msg)                                                 \
-  throw ::eudaq::InitException(exc(msg), __FILE__, __LINE__, EUDAQ_FUNC)
-#define EUDAQ_THROW(msg) EUDAQ_THROWX(::eudaq::LoggedException, (msg))
-#define EUDAQ_THROW_NOLOG(msg) EUDAQ_THROWX(::eudaq::Exception, (msg))
+  throw exc(msg,__FILE__, __LINE__, EUDAQ_FUNC)
+#define EUDAQ_THROW(msg) EUDAQ_THROWX(::eudaq::LoggedException,msg)
+#define EUDAQ_THROW_NOLOG(msg) EUDAQ_THROWX(::eudaq::Exception,msg)
 
 #define EUDAQ_EXCEPTIONX(name, base)                                           \
   class name : public base {                                                   \
-  public:                                                                      \
-    name(const std::string &msg) : base(msg) {}                                \
+  public:					                               \
+    name(const std::string &msg, const std::string &file = "",unsigned line = 0,const std::string &func = "") : base(msg, file, line, func) {} \
   }
 
 #define EUDAQ_EXCEPTION(name) EUDAQ_EXCEPTIONX(name, ::eudaq::Exception)
@@ -32,32 +32,17 @@ namespace eudaq {
 
   class DLLEXPORT Exception : public std::exception {
   public:
-    Exception(const std::string &msg);
-    const char *what() const throw() {
-      if (m_text.length() == 0)
-        make_text();
-      return m_text.c_str();
-    }
-    // This shouldn't really be const, but it must be callable on temporary
-    // objects...
-    const Exception &SetLocation(const std::string &file = "",
-                                 unsigned line = 0,
-                                 const std::string &func = "") const;
+    Exception(const std::string &msg, const std::string &file = "",unsigned line = 0,const std::string &func = "");
+    const char* what() const noexcept override;
     virtual ~Exception() throw() {}
 
   protected:
-    std::string m_msg;
-
-  private:
-    void make_text() const;
-    mutable std::string m_text;
-    mutable std::string m_file, m_func;
-    mutable unsigned m_line;
+    std::string m_text;
   };
 
   class DLLEXPORT LoggedException : public Exception {
   public:
-    LoggedException(const std::string &msg);
+    LoggedException(const std::string &msg, const std::string &file = "",unsigned line = 0,const std::string &func = "");    
     void Log() const;
     virtual ~LoggedException() throw();
 
@@ -68,14 +53,6 @@ namespace eudaq {
   namespace {
     void do_log(const Exception &) {}
     void do_log(const LoggedException &e) { e.Log(); }
-  }
-
-  template <typename T>
-  const T &InitException(const T &e, const std::string &file, int line = 0,
-                         const std::string func = "") {
-    e.SetLocation(file, line, func);
-    do_log(e); // If it is a LoggedException, send it to be logged already
-    return e;
   }
 
   // Some useful predefined exceptions

--- a/main/lib/core/src/Exception.cc
+++ b/main/lib/core/src/Exception.cc
@@ -4,38 +4,33 @@
 
 namespace eudaq {
 
-  Exception::Exception(const std::string &msg) : m_msg(msg), m_line(0) {}
-
-  const Exception &Exception::SetLocation(const std::string &file,
-                                          unsigned line,
-                                          const std::string &func) const {
-    m_file = file;
-    m_line = line;
-    m_func = func;
-    return *this;
-  }
-
-  void Exception::make_text() const {
-    m_text = m_msg;
-    if (m_file.length() > 0) {
-      m_text += "\n  From " + m_file;
-      if (m_line > 0) {
-        m_text += ":" + to_string(m_line);
+  Exception::Exception(const std::string &msg, const std::string &file,unsigned line,const std::string &func) {
+    m_text = msg;
+    if (file.length() > 0) {
+      m_text += "\n  From " + file;
+      if (line > 0) {
+	m_text += ":" + to_string(line);
       }
     }
-    if (m_func.length() > 0)
-      m_text += "\n  In " + m_func;
+    if (func.length() > 0)
+      m_text += "\n  In " + func;
   }
 
-  LoggedException::LoggedException(const std::string &msg)
-      : Exception(msg), m_logged(false) {}
+  const char* Exception::what() const noexcept {
+    return m_text.c_str();
+  }    
+  
+  LoggedException::LoggedException(const std::string &msg, const std::string &file,unsigned line,const std::string &func) 
+    : Exception(msg,file,line,func), m_logged(false) {
+    do_log(*this);
+  }
 
   void LoggedException::Log() const {
     if (m_logged)
       return;
     // Only log the message once
     eudaq::GetLogger().SendLogMessage(
-        eudaq::LogMessage(m_msg, eudaq::LogMessage::LVL_THROW));
+        eudaq::LogMessage(m_text, eudaq::LogMessage::LVL_THROW));
     m_logged = true;
   }
 

--- a/main/lib/core/src/LinkDef.h
+++ b/main/lib/core/src/LinkDef.h
@@ -14,7 +14,7 @@
 #pragma link C++ nestedclass;
 #pragma link C++ nestedtypedef;
 
-#pragma link C++ namespace corryvreckan;
+#pragma link C++ namespace eudaq;
 #pragma link C++ class eudaq::Exception - !;
 #pragma link C++ class eudaq::LoggedException - !;
 

--- a/main/lib/core/src/LinkDef.h
+++ b/main/lib/core/src/LinkDef.h
@@ -1,0 +1,32 @@
+#ifndef __EudaqCoreDICT__
+#define __EudaqCoreDICT__
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Winconsistent-missing-override"
+
+#include "eudaq/Exception.hh"
+
+#ifdef __CINT__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+#pragma link C++ nestedclass;
+#pragma link C++ nestedtypedef;
+
+#pragma link C++ namespace corryvreckan;
+#pragma link C++ class eudaq::Exception - !;
+#pragma link C++ class eudaq::LoggedException - !;
+
+#pragma link C++ class eudaq::FileNotFoundException - !;
+#pragma link C++ class eudaq::FileExistsException - !;
+#pragma link C++ class eudaq::FileNotWritableException - !;
+#pragma link C++ class eudaq::FileReadException - !;
+#pragma link C++ class eudaq::FileWriteException - !;
+#pragma link C++ class eudaq::FileFormatException - !;
+#pragma link C++ class eudaq::SyncException - !;
+#pragma link C++ class eudaq::CommunicationException - !;
+#pragma link C++ class eudaq::BusError - !;
+
+#endif
+#endif

--- a/monitors/rootmonitor/CMakeLists.txt
+++ b/monitors/rootmonitor/CMakeLists.txt
@@ -37,8 +37,12 @@ include_directories(${CMAKE_BINARY_DIR})
 
 aux_source_directory(src EUDAQ_COMPONENT_SRC)
 
-root_generate_dictionary(R_ROOTMonitor eudaq/ROOTMonitor.hh eudaq/ROOTMonitorWindow.hh LINKDEF include/LinkDef.h)
-list(APPEND EUDAQ_COMPONENT_SRC ${CMAKE_CURRENT_BINARY_DIR}/R_ROOTMonitor.cxx)
+root_generate_dictionary(rootmonitorDict eudaq/ROOTMonitor.hh eudaq/ROOTMonitorWindow.hh
+  LINKDEF include/LinkDef.h
+    MODULE
+    rootmonitor        
+  )
+list(APPEND EUDAQ_COMPONENT_SRC ${CMAKE_CURRENT_BINARY_DIR}/rootmonitorDict.cxx)
 add_library(${EUDAQ_COMPONENT} SHARED ${EUDAQ_COMPONENT_SRC})
 
 target_link_libraries(${EUDAQ_COMPONENT} ${EUDAQ_CORE_LIBRARY} ${EUDAQ_THREADS_LIB} ${ROOT_LIBRARIES})
@@ -50,8 +54,8 @@ install(TARGETS ${EUDAQ_COMPONENT}
   ARCHIVE DESTINATION lib)
 
 if(ROOT_VERSION_MAJOR GREATER 5)
-  set(ROOTProducer_PCM ${CMAKE_CURRENT_BINARY_DIR}/libeudaq_R_ROOTMonitor_rdict.pcm)
-  set(ROOTProducer_MAP ${CMAKE_CURRENT_BINARY_DIR}/libeudaq_R_ROOTMonitor.rootmap)
+  set(ROOTProducer_PCM ${CMAKE_CURRENT_BINARY_DIR}/libeudaq_rootmonitor_rdict.pcm)
+  set(ROOTProducer_MAP ${CMAKE_CURRENT_BINARY_DIR}/libeudaq_rootmonitor.rootmap)
   install(FILES
     ${ROOTProducer_PCM}
     ${ROOTProducer_MAP}


### PR DESCRIPTION
eudaq does not generate any dictionaries. This makes it hard to use in interactive shells or with python.
This PR sets out to at least generate dictionaries for the exception classes, so that exceptions thrown within eudaq can be processed sensibly in python scripts.
Also, the implementation of the Exception classes is cleaned up a bit.