### PR TITLE
FIX: FSM does not allow connection in CONFIGURED state

### DIFF
--- a/main/lib/core/src/RunControl.cc
+++ b/main/lib/core/src/RunControl.cc
@@ -111,7 +111,6 @@ namespace eudaq {
       }
     }
     lk.unlock();
-    m_listening = false;
 
     m_conf->SetSection("");
     for(auto &conn: conn_to_conf){


### PR DESCRIPTION
According to documentation the FSM should allow connections in CONFIGURED state. This was disabled both when starting a run (correct) and when configuring (wrong). Removed the second occurrence.