### PR TITLE
Unbreak EUDAQ2: Allow Compilation without ROOT

### DIFF
--- a/main/lib/core/CMakeLists.txt
+++ b/main/lib/core/CMakeLists.txt
@@ -7,8 +7,17 @@ set(EUDAQ_INCLUDE_DIRS
   ${CMAKE_CURRENT_LIST_DIR}/include/eudaq
   CACHE INTERNAL "directory of eudaq include")
 
-# generate the dictionary source code
-ROOT_GENERATE_DICTIONARY(eudaqCoreDict
+
+include_directories(include)
+include_directories(include/eudaq)
+
+aux_source_directory(src CORE_SRC)
+add_library(${EUDAQ_CORE_LIBRARY} SHARED ${CORE_SRC})
+
+# generate the dictionary source code if ROOT is available
+FIND_PACKAGE(root QUIET)
+IF(ROOT_FOUND)
+  ROOT_GENERATE_DICTIONARY(eudaqCoreDict
     include/eudaq/Exception.hh
     LINKDEF
     src/LinkDef.h
@@ -17,20 +26,23 @@ ROOT_GENERATE_DICTIONARY(eudaqCoreDict
     -I${CMAKE_CURRENT_SOURCE_DIR}
     -I${CMAKE_CURRENT_SOURCE_DIR}/src
     MODULE
-    ${EUDAQ_CORE_LIBRARY} 
-)
-SET_SOURCE_FILES_PROPERTIES(${CMAKE_CURRENT_BINARY_DIR}/eudaqCoreDict.cxx
-  PROPERTIES
-  GENERATED TRUE
-  COMPILE_FLAGS "-Wno-unused-function -Wno-overlength-strings -Wno-zero-as-null-pointer-constant -w -I${CMAKE_CURRENT_SOURCE_DIR}"
-)    
+    ${EUDAQ_CORE_LIBRARY}
+  )
+  SET_SOURCE_FILES_PROPERTIES(${CMAKE_CURRENT_BINARY_DIR}/eudaqCoreDict.cxx
+    PROPERTIES
+    GENERATED TRUE
+    COMPILE_FLAGS "-Wno-unused-function -Wno-overlength-strings -Wno-zero-as-null-pointer-constant -w -I${CMAKE_CURRENT_SOURCE_DIR}"
+    )
+  TARGET_SOURCES(${EUDAQ_CORE_LIBRARY} PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/eudaqCoreDict.cxx)
+
+  # Also install the dictionary objects
+  INSTALL(FILES
+      ${CMAKE_CURRENT_BINARY_DIR}/libcore_rdict.pcm
+      ${CMAKE_CURRENT_BINARY_DIR}/libcore.rootmap
+      DESTINATION lib)
+ENDIF()
 
 
-include_directories(include)
-include_directories(include/eudaq)
-
-aux_source_directory(src CORE_SRC)
-add_library(${EUDAQ_CORE_LIBRARY} SHARED ${CORE_SRC} ${CMAKE_CURRENT_BINARY_DIR}/eudaqCoreDict.cxx)
 set_target_properties(${EUDAQ_CORE_LIBRARY} PROPERTIES DEFINE_SYMBOL "core_EXPORTS" )
 set_target_properties(${EUDAQ_CORE_LIBRARY} PROPERTIES VERSION ${EUDAQ_VERSION_MAJOR}.${EUDAQ_VERSION_MINOR})
 
@@ -50,12 +62,6 @@ install(TARGETS ${EUDAQ_CORE_LIBRARY}
   ARCHIVE DESTINATION lib
   # PUBLIC_HEADER DESTINATION include/eudaq
   )
-
-# Also install the dictionary objects
-INSTALL(FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/libcore_rdict.pcm
-    ${CMAKE_CURRENT_BINARY_DIR}/libcore.rootmap
-    DESTINATION lib)
 
 file(GLOB INC_FILES "${CMAKE_CURRENT_SOURCE_DIR}/include/eudaq/*.hh")
 install(FILES ${INC_FILES} DESTINATION include/eudaq)


### PR DESCRIPTION
PR #656 added a direct ROOT dependency to the EUDAQ2 core library without even checking previously if ROOT is installed and has been found by the build system. Seems like we were all lucky and had ROOT installed anyway.

...unless we tried to build for an embedded 32-bit ARM system without ROOT :wink: 

I now quietly check for ROOT presence and enable dictionary generation in case we have it, and not else. This should be fine, because for using the resulting ROOT dicts you need ROOT anyway. Sorry, circular sentence.

(cc) @ffeindt @herkerta 