### PR TITLE
Adjust Producer.hh to support MuPix8_DAQ

### DIFF
--- a/main/lib/core/include/eudaq/Producer.hh
+++ b/main/lib/core/include/eudaq/Producer.hh
@@ -53,10 +53,11 @@ namespace eudaq {
     void OnReset() override final;
     void OnTerminate() override final;
     void OnStatus() override;
-    
+  
+  protected:
+    uint32_t m_evt_c;
   private:
     uint32_t m_pdc_n;
-    uint32_t m_evt_c;
     std::mutex m_mtx_sender;
     std::map<std::string, std::shared_ptr<DataSender>> m_senders;
   };


### PR DESCRIPTION
Unfortunately compiling MuPix8 with EUDAQ support is only possible with this patch. Separate to #696 since this changes core components and I'm not sure what the policy here is.