### PR TITLE
Update cmake FindPython

### DIFF
--- a/main/lib/python/CMakeLists.txt
+++ b/main/lib/python/CMakeLists.txt
@@ -3,10 +3,10 @@ if(NOT EUDAQ_BUILD_PYTHON)
   return()
 endif()
 #find_package(PythonLibsNew REQUIRED)
-find_package(PythonLibs REQUIRED)
+find_package(Python REQUIRED COMPONENTS Development)
 
 include_directories(${EUDAQ_INCLUDE_DIRS})
-include_directories(${PYTHON_INCLUDE_DIRS})
+include_directories(${Python_INCLUDE_DIRS})
 aux_source_directory(src EUDAQ_COMPONENT_SRC)
 
 set(PYBIND_NAME_VER pybind11-2.5.0)
@@ -28,7 +28,7 @@ add_custom_command(
 set(CMAKE_SHARED_LIBRARY_PREFIX "")
 set(CMAKE_SHARED_MODULE_PREFIX  "")
 add_library(pyeudaq SHARED ${EUDAQ_COMPONENT_SRC} ${PYBIND_HEADER_FILE})
-target_link_libraries(pyeudaq ${EUDAQ_CORE_LIBRARY} ${EUDAQ_THREADS_LIB} ${PYTHON_LIBRARIES})
+target_link_libraries(pyeudaq ${EUDAQ_CORE_LIBRARY} ${EUDAQ_THREADS_LIB} ${Python_LIBRARIES})
 
 if (APPLE)
     set_property(TARGET pyeudaq PROPERTY OUTPUT_NAME "pyeudaq.so")


### PR DESCRIPTION
`FindPythonLibs` is [deprecated](https://cmake.org/cmake/help/latest/module/FindPythonLibs.html) since `cmake==3.12`. Since Ubuntu 18 that was shipped with `cmake < 3.12` is EOL since April 2023, it might make sense to update to the newer `FindPython`.

Tested and works on Debian 12, cmake 3.25, python 3.10.
