### PR TITLE
TluRawEvent2StdEventConverter: fix time stamp unit consistency.

### DIFF
--- a/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
+++ b/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
@@ -129,7 +129,7 @@ bool TluRawEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Standa
    // Set times for StdEvent in picoseconds (timestamps provided in nanoseconds):
   d2->SetTimeBegin(ts);
   d2->SetTimeEnd(d1->GetTimestampEnd() * 1000);
-  d2->SetTimestamp(ts, d1->GetTimestampEnd(), d1->IsFlagTimestamp());
+  d2->SetTimestamp(ts, d1->GetTimestampEnd() * 1000, d1->IsFlagTimestamp());
 
   // Identify the detetor type
   d2->SetDetectorType("TLU");


### PR DESCRIPTION
We store `time_begin` and `time_end` in separate member variables in 'Events' and 'StdEvents'. Not entirely sure if this is healthy, but will create a lot of chaos to fix this. This way we keep them consistent at least. Should not change anything in Corry, as we are not actually using them, but it might prevent future trouble.