### PR TITLE
Fix weird CLING issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ CMAKE_MINIMUM_REQUIRED(VERSION 3.6.3 FATAL_ERROR)
 IF(COMMAND CMAKE_POLICY)
     CMAKE_POLICY(SET CMP0003 NEW) # change linker path search behaviour
     CMAKE_POLICY(SET CMP0048 NEW) # set project version
+    CMAKE_POLICY(SET CMP0065 OLD) # Use old linking behavior
     IF(${CMAKE_VERSION} VERSION_GREATER "3.13")
         CMAKE_POLICY(SET CMP0077 NEW) # allow overwriting options with normal variables
         CMAKE_POLICY(SET CMP0079 NEW) # Allow lookup of linking libraries in other directories

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,13 +15,6 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     include(CTest)
 endif()
 
-if(COMMAND CMAKE_POLICY)
-  if(${CMAKE_VERSION} VERSION_GREATER "3.13")
-    cmake_policy(SET CMP0079 NEW) # Allow lookup of linking libraries in other directories
-    cmake_policy(SET CMP0077 NEW) # allow overwriting options with normal variables    
-  endif()
-endif(COMMAND CMAKE_POLICY)
-
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 include(CMakeCompatibility)
 include(Platform)


### PR DESCRIPTION
This reverts a few CMake linking policies which seem to have created issues with ROOT's Cling:

```
#pragma clang diagnostic pop
  ==== SOURCE END ====
Error in <TClingCallFunc::Exec(address, interpVal)>: Called with no wrapper, not implemented!
IncrementalExecutor::executeFunction: symbol '_ZN15OnlineMonWindow10autoUpdateEv' unresolved while linking symbol '__cf_46'!
You are probably missing the definition of OnlineMonWindow::autoUpdate()
Maybe you need to load the corresponding shared library?
Error in <TClingCallFunc::make_wrapper>: Failed to compile
  ==== SOURCE BEGIN ====
#pragma clang diagnostic push
#pragma clang diagnostic ignored "-Wformat-security"
__attribute__((used)) __attribute__((annotate("__cling__ptrcheck(off)")))
extern "C" void __cf_46(void* obj, int nargs, void** args, void* ret)
{
   ((OnlineMonWindow*)obj)->autoUpdate();
   return;
}
#pragma clang diagnostic pop
  ==== SOURCE END ====
```