### PR TITLE
extending github actions: qt5/qt6 and ROOT for ubuntu

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -19,11 +19,16 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    
+    - name: install qt
+      run: |
+        sudo apt-get update
+        sudo apt-get install qtcreator qtbase5-dev qt5-qmake
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -D USER_BUILD_TLU_ONLY_CONVERTER=ON -D USER_EUDET_DUILD=ON -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      run: cmake -D EUDAQ_BUILD_GUI=ON -D USER_BUILD_TLU_ONLY_CONVERTER=ON -D USER_EUDET_DUILD=ON -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
     - name: Build
       # Build your program with the given configuration

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -19,6 +19,8 @@ jobs:
     strategy:
       matrix:
         qt_version: [5, 6]
+        
+    name: eudaq_full_build-ubuntu-latest-qt-${{matrix.qt_version}}
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -16,19 +16,44 @@ jobs:
     # You can convert this to a matrix build if you need cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        qt_version: [5, 6]
 
     steps:
     - uses: actions/checkout@v3
     
-    - name: install qt
+    - name: update repo
       run: |
         sudo apt-get update
-        sudo apt-get install qtcreator qtbase5-dev qt5-qmake
+
+    - name: install qt
+      run: |
+        if [ "${{ matrix.qt_version }}" -eq "5" ];
+        then 
+          sudo apt-get install qtbase5-dev qt5-qmake
+        fi
+        if [ "${{ matrix.qt_version }}" -eq "6" ]; 
+        then 
+          sudo apt-get install qt6-base-dev
+        fi
+      shell: bash
+        
+    - name: install CERN ROOT
+      run: |
+        export CERN_ROOT_DOWNLOAD_NAME=root_v6.30.04.Linux-ubuntu22.04-x86_64-gcc11.4.tar.gz
+        wget -nv https://root.cern/download/$CERN_ROOT_DOWNLOAD_NAME
+        tar -xzf $CERN_ROOT_DOWNLOAD_NAME
+        rm -f $CERN_ROOT_DOWNLOAD_NAME
+        mkdir -p ~/eudaq_dependencies/ubuntu22-x86_64/
+        mv root ~/eudaq_dependencies/ubuntu22-x86_64/
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -D EUDAQ_BUILD_GUI=ON -D USER_BUILD_TLU_ONLY_CONVERTER=ON -D USER_EUDET_DUILD=ON -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      run: |
+        source ~/eudaq_dependencies/ubuntu22-x86_64/root/bin/thisroot.sh
+        cmake -D EUDAQ_BUILD_STDEVENT_MONITOR=ON -D EUDAQ_BUILD_GUI=ON -D USER_BUILD_TLU_ONLY_CONVERTER=ON -D USER_EUDET_BUILD=ON -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
     - name: Build
       # Build your program with the given configuration

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 EUDAQ version 2
 =====
 
+![Github actions](https://github.com/eudaq/eudaq/actions/workflows/cmake.yml/badge.svg)
 [![Build status](https://ci.appveyor.com/api/projects/status/n3tq45kkupyvjihg/branch/master?svg=true)](https://ci.appveyor.com/project/eudaq/eudaq/branch/master)
 
 EUDAQ is a Generic Multi-platform Data Acquisition Framework.


### PR DESCRIPTION
Minimum extension of github actions:
- ubuntu-latest installing latest CERN ROOT and qt5/qt6 resulting in two jobs
- trying to build stdeventmonitor and gui
- adding badge to README.md
