### PR TITLE
port gui to Qt6 (keeping Qt5 as fallback)

### DIFF
--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -1,59 +1,105 @@
 # 3.16 mininum for Qt6 according to  professional cmake: a practical guide
 cmake_minimum_required(VERSION 3.16.0)
 
+#include(CMakeDependentOption)
+
 find_package(Qt6 QUIET COMPONENTS Widgets)
 
 if (NOT Qt6_FOUND)
-find_package(Qt5 5.15 QUIET COMPONENTS Widgets)
+  find_package(Qt5 5.15 QUIET COMPONENTS Widgets)
 endif()
 
-cmake_dependent_option(EUDAQ_BUILD_GUI "Compile GUI executables (requires QT6 or QT5)" ON
-  "Qt6Widgets_FOUND" OFF)
+set(Qt5_or_Qt6_FOUND (Qt6_FOUND OR Qt5_FOUND))
 
-#include(CMakeDependentOption)
+cmake_dependent_option(EUDAQ_BUILD_GUI "Compile GUI executables (requires QT6 or QT5)" ON
+  "Qt5_or_Qt6_FOUND" OFF)
+
 if(NOT EUDAQ_BUILD_GUI)
-    message(STATUS "GUIs of executables (euRun, euLog) are NOT to be built (EUDAQ_BUILD_GUI=OFF)")
+  message(STATUS "GUIs of executables (euRun, euLog) are NOT to be built (EUDAQ_BUILD_GUI=OFF)")
+  if(NOT Qt5_or_Qt6_FOUND)
+     message(STATUS "reason: neither Qt5 nor Qt6 found")
+  endif()
   return()
 endif()
 
-message(STATUS "GUIs of executables (euRun, euLog) are to be built (EUDAQ_BUILD_GUI=ON)")
+if(Qt6_FOUND)
+  message(STATUS "GUIs of executables (euRun, euLog) are to be built (EUDAQ_BUILD_GUI=ON) with Qt6")
 
-set(CMAKE_AUTOUIC YES)
-set(CMAKE_AUTORCC YES)
-set(CMAKE_INCLUDE_CURRENT_DIR YES)
+  set(CMAKE_AUTOUIC YES)
+  set(CMAKE_AUTORCC YES)
+  set(CMAKE_INCLUDE_CURRENT_DIR YES)
 
-qt_wrap_cpp(euRun_MOCSrcs include/RunControlModel.hh include/euRun.hh)
-qt_wrap_ui(euRun_UIrcs ui/euRun.ui)
+  qt_wrap_cpp(euRun_MOCSrcs include/RunControlModel.hh include/euRun.hh)
+  qt_wrap_ui(euRun_UIrcs ui/euRun.ui)
 
-add_executable(euRun 
-  ${euRun_MOCSrcs}
-  ${euRun_UIrcs}
-  src/euRun.cxx
-  src/euRun.cc
-  src/RunControlModel.cc
-  src/euRun.rc
-  src/scanHelper.cc
-  images/euRun.qrc
-  )
+  add_executable(euRun 
+    ${euRun_MOCSrcs}
+    ${euRun_UIrcs}
+    src/euRun.cxx
+    src/euRun.cc
+    src/RunControlModel.cc
+    src/euRun.rc
+    src/scanHelper.cc
+    images/euRun.qrc
+    )
   
-target_include_directories(euRun PRIVATE include )
-target_link_libraries(euRun ${EUDAQ_CORE_LIBRARY} Qt6::Widgets)
+  target_include_directories(euRun PRIVATE include )
+  target_link_libraries(euRun ${EUDAQ_CORE_LIBRARY} Qt6::Widgets)
 
-qt_wrap_cpp(euLog_MOCSrcs include/LogCollectorModel.hh include/euLog.hh)
-qt_wrap_ui(euLog_UIrcs ui/euLog.ui ui/LogDialog.ui)
+  qt_wrap_cpp(euLog_MOCSrcs include/LogCollectorModel.hh include/euLog.hh)
+  qt_wrap_ui(euLog_UIrcs ui/euLog.ui ui/LogDialog.ui)
 
-add_executable(euLog 
-  ${euLog_MOCSrcs}
-  ${euLog_UIrcs}
-  src/euLog.cxx
-  src/euLog.cc
-  src/LogCollectorModel.cc
-  images/euLog.qrc
-  )
+  add_executable(euLog 
+    ${euLog_MOCSrcs}
+    ${euLog_UIrcs}
+    src/euLog.cxx
+    src/euLog.cc
+    src/LogCollectorModel.cc
+    images/euLog.qrc
+    )
 
 
-target_include_directories(euLog PRIVATE include )
-target_link_libraries(euLog ${EUDAQ_CORE_LIBRARY} Qt6::Widgets)
+  target_include_directories(euLog PRIVATE include )
+  target_link_libraries(euLog ${EUDAQ_CORE_LIBRARY} Qt6::Widgets)
+elseif()
+  message(STATUS "GUIs of executables (euRun, euLog) are to be built (EUDAQ_BUILD_GUI=ON) with Qt5")
+
+  set(CMAKE_AUTOUIC YES)
+  set(CMAKE_AUTORCC YES)
+  set(CMAKE_INCLUDE_CURRENT_DIR YES)
+
+  qt_wrap_cpp(euRun_MOCSrcs include/RunControlModel.hh include/euRun.hh)
+  qt_wrap_ui(euRun_UIrcs ui/euRun.ui)
+
+  add_executable(euRun 
+    ${euRun_MOCSrcs}
+    ${euRun_UIrcs}
+    src/euRun.cxx
+    src/euRun.cc
+    src/RunControlModel.cc
+    src/euRun.rc
+    src/scanHelper.cc
+    images/euRun.qrc
+    )
+  
+  target_include_directories(euRun PRIVATE include )
+  target_link_libraries(euRun ${EUDAQ_CORE_LIBRARY} Qt5::Widgets)
+
+  qt_wrap_cpp(euLog_MOCSrcs include/LogCollectorModel.hh include/euLog.hh)
+  qt_wrap_ui(euLog_UIrcs ui/euLog.ui ui/LogDialog.ui)
+
+  add_executable(euLog 
+    ${euLog_MOCSrcs}
+    ${euLog_UIrcs}
+    src/euLog.cxx
+    src/euLog.cc
+    src/LogCollectorModel.cc
+    images/euLog.qrc
+    )
+
+  target_include_directories(euLog PRIVATE include )
+  target_link_libraries(euLog ${EUDAQ_CORE_LIBRARY} Qt5::Widgets)
+endif()
 
 
 install(TARGETS euRun euLog

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -1,16 +1,14 @@
 # 3.16 mininum for Qt6 according to  professional cmake: a practical guide
 cmake_minimum_required(VERSION 3.16.0)
 
-find_package(Qt5 5.15 REQUIRED
-COMPONENTS Widgets Core
-)
+find_package(Qt6 QUIET COMPONENTS Widgets)
 
-set(CMAKE_AUTOUIC YES)
-set(CMAKE_AUTORCC YES)
-set(CMAKE_INCLUDE_CURRENT_DIR YES)
+if (NOT Qt6_FOUND)
+find_package(Qt5 5.15 QUIET COMPONENTS Widgets)
+endif()
 
-cmake_dependent_option(EUDAQ_BUILD_GUI "Compile GUI executables (requires QT5)" ON
-  "Qt5Widgets_FOUND" OFF)
+cmake_dependent_option(EUDAQ_BUILD_GUI "Compile GUI executables (requires QT6 or QT5)" ON
+  "Qt6Widgets_FOUND" OFF)
 
 #include(CMakeDependentOption)
 if(NOT EUDAQ_BUILD_GUI)
@@ -20,37 +18,42 @@ endif()
 
 message(STATUS "GUIs of executables (euRun, euLog) are to be built (EUDAQ_BUILD_GUI=ON)")
 
-qt5_wrap_cpp(euRun_MOCSrcs include/RunControlModel.hh include/euRun.hh)
+set(CMAKE_AUTOUIC YES)
+set(CMAKE_AUTORCC YES)
+set(CMAKE_INCLUDE_CURRENT_DIR YES)
+
+qt_wrap_cpp(euRun_MOCSrcs include/RunControlModel.hh include/euRun.hh)
+qt_wrap_ui(euRun_UIrcs ui/euRun.ui)
 
 add_executable(euRun 
   ${euRun_MOCSrcs}
+  ${euRun_UIrcs}
   src/euRun.cxx
   src/euRun.cc
   src/RunControlModel.cc
   src/euRun.rc
   src/scanHelper.cc
-  ui/euRun.ui
   images/euRun.qrc
   )
   
 target_include_directories(euRun PRIVATE include )
-target_link_libraries(euRun ${EUDAQ_CORE_LIBRARY} Qt5::Widgets)
+target_link_libraries(euRun ${EUDAQ_CORE_LIBRARY} Qt6::Widgets)
 
-qt5_wrap_cpp(euLog_MOCSrcs include/LogCollectorModel.hh include/euLog.hh)
+qt_wrap_cpp(euLog_MOCSrcs include/LogCollectorModel.hh include/euLog.hh)
+qt_wrap_ui(euLog_UIrcs ui/euLog.ui ui/LogDialog.ui)
 
 add_executable(euLog 
   ${euLog_MOCSrcs}
+  ${euLog_UIrcs}
   src/euLog.cxx
   src/euLog.cc
   src/LogCollectorModel.cc
-  ui/LogDialog.ui 
-  ui/euLog.ui
   images/euLog.qrc
   )
 
 
 target_include_directories(euLog PRIVATE include )
-target_link_libraries(euLog ${EUDAQ_CORE_LIBRARY} Qt5::Widgets)
+target_link_libraries(euLog ${EUDAQ_CORE_LIBRARY} Qt6::Widgets)
 
 
 install(TARGETS euRun euLog

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -3,11 +3,9 @@ cmake_minimum_required(VERSION 3.16.0)
 
 #include(CMakeDependentOption)
 
-find_package(Qt6 COMPONENTS Widgets)
+find_package(Qt6 QUIET COMPONENTS Widgets)
 
-if (NOT Qt6_FOUND)
-  find_package(Qt5 5.15 COMPONENTS Widgets)
-endif()
+find_package(Qt5 5.15 QUIET COMPONENTS Widgets)
 
 set(Qt5_or_Qt6_FOUND (Qt6_FOUND OR Qt5_FOUND))
 

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -61,6 +61,12 @@ if(Qt6_FOUND)
 
   target_include_directories(euLog PRIVATE include )
   target_link_libraries(euLog ${EUDAQ_CORE_LIBRARY} Qt6::Widgets)
+
+  install(TARGETS euRun euLog
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib)  
+    
 elseif()
   message(STATUS "GUIs of executables (euRun, euLog) are to be built (EUDAQ_BUILD_GUI=ON) with Qt5")
 
@@ -99,10 +105,10 @@ elseif()
 
   target_include_directories(euLog PRIVATE include )
   target_link_libraries(euLog ${EUDAQ_CORE_LIBRARY} Qt5::Widgets)
+
+  install(TARGETS euRun euLog
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib)  
+    
 endif()
-
-
-install(TARGETS euRun euLog
-  RUNTIME DESTINATION bin
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib)

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -1,23 +1,33 @@
 # 3.16 mininum for Qt6 according to  professional cmake: a practical guide
 cmake_minimum_required(VERSION 3.16.0)
 
-#include(CMakeDependentOption)
+include(CMakeDependentOption)
 
-find_package(Qt6 QUIET COMPONENTS Widgets)
+option(EUDAQ_BUILD_GUI "Compile GUI executables (requires QT6 or QT5)" ON)
+cmake_dependent_option(EUDAQ_FORCE_QT5 "Force usage QT5 even if Qt6 is available" OFF "EUDAQ_BUILD_GUI" OFF)
 
-find_package(Qt5 5.15 QUIET COMPONENTS Widgets)
+if(NOT EUDAQ_FORCE_QT5)
+  message(STATUS "checking for Qt6")
+  find_package(Qt6 COMPONENTS Widgets)
+endif()
+
+if((NOT Qt6_FOUND) OR (NOT DEFINED Qt6_FOUND))
+  message(STATUS "checking for Qt5")
+  find_package(Qt5 5.15 COMPONENTS Widgets)
+endif()
 
 set(Qt5_or_Qt6_FOUND FALSE)
 set(Qt5_or_Qt6_FOUND (Qt6_FOUND OR Qt5_FOUND))
 
-option(EUDAQ_BUILD_GUI "Compile GUI executables (requires QT6 or QT5)" ON)
 
 if(EUDAQ_BUILD_GUI)
-  message(STATUS "GUIs of executables (euRun, euLog) are to be built (EUDAQ_BUILD_GUI=OFF)")
-  if(NOT Qt5_or_Qt6_FOUND)
-     message(STATUS "but finally it is not possible as neither Qt5 nor Qt6 were found")
+  if((NOT Qt5_or_Qt6_FOUND) AND (NOT EUDAQ_FORCE_QT5))
+     message(STATUS "GUIs of executables (euRun, euLog) were meant to be built (EUDAQ_BUILD_GUI=ON) but finally it is not possible as neither Qt5 nor Qt6 were found")
+     return()     
+  elseif(NOT Qt5_or_Qt6_FOUND)
+     message(STATUS "GUIs of executables (euRun, euLog) were meant to be built (EUDAQ_BUILD_GUI=ON) but finally it is not possible as Qt5 was forced but not found")
+     return()     
   endif()
-  return()
 else()
   message(STATUS "GUIs of executables (euRun, euLog) are NOT to be built (EUDAQ_BUILD_GUI=OFF)")
   return()
@@ -67,8 +77,11 @@ if(Qt6_FOUND)
     RUNTIME DESTINATION bin
     LIBRARY DESTINATION lib
     ARCHIVE DESTINATION lib)  
-    
-elseif()
+
+   return()    
+endif()
+
+if(Qt5_FOUND)
   message(STATUS "GUIs of executables (euRun, euLog) are to be built (EUDAQ_BUILD_GUI=ON) with Qt5")
 
   set(CMAKE_AUTOUIC YES)
@@ -111,5 +124,6 @@ elseif()
     RUNTIME DESTINATION bin
     LIBRARY DESTINATION lib
     ARCHIVE DESTINATION lib)  
-    
+   
+   return() 
 endif()

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -3,10 +3,10 @@ cmake_minimum_required(VERSION 3.16.0)
 
 #include(CMakeDependentOption)
 
-find_package(Qt6 QUIET COMPONENTS Widgets)
+find_package(Qt6 COMPONENTS Widgets)
 
 if (NOT Qt6_FOUND)
-  find_package(Qt5 5.15 QUIET COMPONENTS Widgets)
+  find_package(Qt5 5.15 COMPONENTS Widgets)
 endif()
 
 set(Qt5_or_Qt6_FOUND (Qt6_FOUND OR Qt5_FOUND))

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -7,16 +7,19 @@ find_package(Qt6 QUIET COMPONENTS Widgets)
 
 find_package(Qt5 5.15 QUIET COMPONENTS Widgets)
 
+set(Qt5_or_Qt6_FOUND FALSE)
 set(Qt5_or_Qt6_FOUND (Qt6_FOUND OR Qt5_FOUND))
 
-cmake_dependent_option(EUDAQ_BUILD_GUI "Compile GUI executables (requires QT6 or QT5)" ON
-  "Qt5_or_Qt6_FOUND" OFF)
+option(EUDAQ_BUILD_GUI "Compile GUI executables (requires QT6 or QT5)" ON)
 
-if(NOT EUDAQ_BUILD_GUI)
-  message(STATUS "GUIs of executables (euRun, euLog) are NOT to be built (EUDAQ_BUILD_GUI=OFF)")
+if(EUDAQ_BUILD_GUI)
+  message(STATUS "GUIs of executables (euRun, euLog) are to be built (EUDAQ_BUILD_GUI=OFF)")
   if(NOT Qt5_or_Qt6_FOUND)
-     message(STATUS "reason: neither Qt5 nor Qt6 found")
+     message(STATUS "but finally it is not possible as neither Qt5 nor Qt6 were found")
   endif()
+  return()
+else()
+  message(STATUS "GUIs of executables (euRun, euLog) are NOT to be built (EUDAQ_BUILD_GUI=OFF)")
   return()
 endif()
 

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -1,86 +1,59 @@
-include(CMakeDependentOption)
-find_package(Qt5Widgets CONFIG)
+# 3.16 mininum for Qt6 according to  professional cmake: a practical guide
+cmake_minimum_required(VERSION 3.16.0)
+
+find_package(Qt5 5.15 REQUIRED
+COMPONENTS Widgets Core
+)
+
+set(CMAKE_AUTOUIC YES)
+set(CMAKE_AUTORCC YES)
+set(CMAKE_INCLUDE_CURRENT_DIR YES)
 
 cmake_dependent_option(EUDAQ_BUILD_GUI "Compile GUI executables (requires QT5)" ON
   "Qt5Widgets_FOUND" OFF)
 
+#include(CMakeDependentOption)
 if(NOT EUDAQ_BUILD_GUI)
     message(STATUS "GUIs of executables (euRun, euLog) are NOT to be built (EUDAQ_BUILD_GUI=OFF)")
   return()
 endif()
+
 message(STATUS "GUIs of executables (euRun, euLog) are to be built (EUDAQ_BUILD_GUI=ON)")
 
-find_package(Qt5Widgets REQUIRED)
-message(STATUS "Qt5Widgets: ${Qt5Widgets_DIR}")
-set(EXTERNAL_LIB_QT Qt5::Widgets)
-include_directories(${Qt5Widgets_INCLUDE_DIRS})
-add_definitions(${Qt5Widgets_DEFINITIONS})
+qt5_wrap_cpp(euRun_MOCSrcs include/RunControlModel.hh include/euRun.hh)
 
-set(CMAKE_INCLUDE_CURRENT_DIR ON)
-include_directories(include)
-
-set(RUN_GUI_SRC
+add_executable(euRun 
+  ${euRun_MOCSrcs}
   src/euRun.cxx
   src/euRun.cc
   src/RunControlModel.cc
   src/euRun.rc
   src/scanHelper.cc
+  ui/euRun.ui
+  images/euRun.qrc
   )
-qt5_wrap_ui(euRun_UISrcs ui/euRun.ui)
-qt5_wrap_cpp(euRun_MOCSrcs include/RunControlModel.hh include/euRun.hh)
-list(APPEND RUN_GUI_SRC ${euRun_UISrcs} ${euRun_MOCSrcs})
-add_executable(euRun ${RUN_GUI_SRC})
-target_link_libraries(euRun ${EUDAQ_CORE_LIBRARY} ${EXTERNAL_LIB_QT})
-list(APPEND INSTALL_TARGETS euRun)
+  
+target_include_directories(euRun PRIVATE include )
+target_link_libraries(euRun ${EUDAQ_CORE_LIBRARY} Qt5::Widgets)
 
-set(LOG_GUI_SRC
+qt5_wrap_cpp(euLog_MOCSrcs include/LogCollectorModel.hh include/euLog.hh)
+
+add_executable(euLog 
+  ${euLog_MOCSrcs}
   src/euLog.cxx
   src/euLog.cc
   src/LogCollectorModel.cc
-  # src/euLog.rc
-  )
-
-set(PRD_GUI_SRC
-  src/euProd.cxx
-  src/euProd.cc
-  # src/euProd.rc
+  ui/LogDialog.ui 
+  ui/euLog.ui
+  images/euLog.qrc
   )
 
 
-set(MODULE_SRC
-  src/euLog.cc
-  src/LogCollectorModel.cc
-  src/euProd.cc
-  # src/euLog.rc
-  # src/euProd.rc
-  )
+target_include_directories(euLog PRIVATE include )
+target_link_libraries(euLog ${EUDAQ_CORE_LIBRARY} Qt5::Widgets)
 
 
-qt5_wrap_cpp(euLog_MOCSrcs include/LogCollectorModel.hh include/euLog.hh )
-qt5_wrap_ui(euLog_UISrcs ui/LogDialog.ui ui/euLog.ui)
-list(APPEND MODULE_SRC ${euLog_UISrcs} ${euLog_MOCSrcs})
-
-qt5_wrap_cpp(euProd_MOCSrcs include/euProd.hh )
-qt5_wrap_ui(euProd_UISrcs ui/euProd.ui)
-list(APPEND MODULE_SRC ${euProd_UISrcs} ${euProd_MOCSrcs})
-
-get_filename_component(MODULE_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)
-set(EUDAQ_MODULE ${EUDAQ_PREFIX}module_${MODULE_NAME})
-add_library(${EUDAQ_MODULE} SHARED ${MODULE_SRC})
-target_link_libraries(${EUDAQ_MODULE} ${EUDAQ_CORE_LIBRARY} ${EXTERNAL_LIB_QT})
-list(APPEND INSTALL_TARGETS ${EUDAQ_MODULE})
-
-add_executable(euLog src/euLog.cxx src/euLog.rc)
-set_property(TARGET euLog PROPERTY PROJECT_LABEL "BinEuLog") 
-target_link_libraries(euLog ${EUDAQ_CORE_LIBRARY} ${EXTERNAL_LIB_QT})
-list(APPEND INSTALL_TARGETS euLog)
-
-# add_executable(euProd src/euProd.cxx src/euProd.rc)
-# set_property(TARGET euProd PROPERTY PROJECT_LABEL "BinEuProd")
-# target_link_libraries(euProd ${EUDAQ_CORE_LIBRARY} ${EXTERNAL_LIB_QT})
-# list(APPEND INSTALL_TARGETS euProd)
-
-install(TARGETS ${INSTALL_TARGETS}
+install(TARGETS euRun euLog
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib)

--- a/gui/images/euLog.qrc
+++ b/gui/images/euLog.qrc
@@ -1,0 +1,5 @@
+<!DOCTYPE RCC><RCC version="1.0">
+<qresource>
+    <file>euLog.ico</file>
+</qresource>
+</RCC>

--- a/gui/images/euRun.qrc
+++ b/gui/images/euRun.qrc
@@ -1,0 +1,5 @@
+<!DOCTYPE RCC><RCC version="1.0">
+<qresource>
+    <file>euRun.ico</file>
+</qresource>
+</RCC>

--- a/gui/include/LogCollectorModel.hh
+++ b/gui/include/LogCollectorModel.hh
@@ -3,7 +3,7 @@
 
 #include "eudaq/LogMessage.hh"
 #include <QAbstractListModel>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <vector>
 #include <stdexcept>
 #include <iostream>
@@ -32,7 +32,7 @@ public:
   bool Match(const LogMessage &msg);
 private:
   bool m_set;
-  QRegExp m_regexp;
+  QRegularExpression m_regexp;
 };
 
 class LogSorter {

--- a/gui/include/euRun.hh
+++ b/gui/include/euRun.hh
@@ -12,7 +12,7 @@
 #include <QTimer>
 #include <QInputDialog>
 #include <QSettings>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QString>
 #include <QGridLayout>
 

--- a/gui/src/LogCollectorModel.cc
+++ b/gui/src/LogCollectorModel.cc
@@ -164,8 +164,7 @@ QString LogMessage::ColumnName(int i) {
 }
 
 LogSearcher::LogSearcher() : m_set(false) {
-  m_regexp.setPatternSyntax(QRegExp::Wildcard);
-  m_regexp.setCaseSensitivity(Qt::CaseInsensitive);
+  m_regexp.setPatternOptions(QRegularExpression::CaseInsensitiveOption);
 }
 
 void LogSearcher::SetSearch(const std::string &regexp) {
@@ -177,7 +176,7 @@ bool LogSearcher::Match(const LogMessage &msg) {
   if (!m_set)
     return true;
   for (int i = 0; i < LogMessage::NumColumns(); ++i) {
-    if (m_regexp.indexIn(msg[i]) >= 0)
+    if (m_regexp.match(msg[i]).hasMatch())
       return true;
   }
   return false;

--- a/gui/src/euLog.cc
+++ b/gui/src/euLog.cc
@@ -28,6 +28,7 @@ LogCollectorGUI::LogCollectorGUI(const std::string &name,
     eudaq::LogCollector(name, runcontrol), m_delegate(&m_model) {
   setupUi(this);
   std::string filename;
+  setWindowIcon(QIcon(":/euLog.ico"));
   viewLog->setModel(&m_model);
   viewLog->setItemDelegate(&m_delegate);
   for (int i = 0; i < LogMessage::NumColumns(); ++i) {

--- a/gui/src/euLog.cc
+++ b/gui/src/euLog.cc
@@ -24,7 +24,7 @@ void LogItemDelegate::paint(QPainter *painter,
 
 LogCollectorGUI::LogCollectorGUI(const std::string &name,
 				 const std::string &runcontrol)
-  : QMainWindow(0, 0),
+  : QMainWindow(0, Qt::Widget),
     eudaq::LogCollector(name, runcontrol), m_delegate(&m_model) {
   setupUi(this);
   std::string filename;

--- a/gui/src/euRun.cc
+++ b/gui/src/euRun.cc
@@ -77,6 +77,7 @@ RunControlGUI::RunControlGUI()
   }
 
   setWindowTitle("eudaq Run Control " PACKAGE_VERSION);
+  setWindowIcon(QIcon(":/euRun.ico"));
   connect(&m_timer_display, SIGNAL(timeout()), this, SLOT(DisplayTimer()));
   connect(&m_scanningTimer,SIGNAL(timeout()), this, SLOT(nextStep()));
   m_timer_display.start(1000); // internal update time of GUI

--- a/gui/src/euRun.cc
+++ b/gui/src/euRun.cc
@@ -4,6 +4,7 @@
 #include "euRun.hh"
 #include "Colours.hh"
 #include "eudaq/Config.hh"
+#include "eudaq/Utils.hh"
 
 using std::cout;
 using std::endl;

--- a/gui/src/euRun.cc
+++ b/gui/src/euRun.cc
@@ -8,7 +8,7 @@
 using std::cout;
 using std::endl;
 RunControlGUI::RunControlGUI()
-  : QMainWindow(0, 0),
+  : QMainWindow(0, Qt::Widget),
     m_display_col(0),
     m_scan_active(false),
     m_scan_interrupt_received(false),
@@ -257,10 +257,10 @@ eudaq::Status::State RunControlGUI::updateInfos(){
       }
     }
 
-    QRegExp rx_init(".+(\\.ini$)");
-    QRegExp rx_conf(".+(\\.conf$)");
-    bool confLoaded = rx_conf.exactMatch(txtConfigFileName->text());
-    bool initLoaded = rx_init.exactMatch(txtInitFileName->text());
+    QRegularExpression rx_init(".+(\\.ini$)");
+    QRegularExpression rx_conf(".+(\\.conf$)");
+    bool confLoaded = rx_conf.match(txtConfigFileName->text()).hasMatch();
+    bool initLoaded = rx_init.match(txtInitFileName->text()).hasMatch();
 
     btnInit->setEnabled(state == eudaq::Status::STATE_UNINIT && initLoaded);
     btnConfig->setEnabled((state == eudaq::Status::STATE_UNCONF ||

--- a/main/lib/core/include/eudaq/Status.hh
+++ b/main/lib/core/include/eudaq/Status.hh
@@ -9,6 +9,11 @@
 #include <map>
 #include <ostream>
 
+// due to collision with GetMessage introduced by windows.h on Windows systems
+#ifdef GetMessage
+#undef GetMessage
+#endif
+
 namespace eudaq{
   class Serializer;
   class Deserializer;

--- a/main/lib/core/include/eudaq/Utils.hh
+++ b/main/lib/core/include/eudaq/Utils.hh
@@ -34,7 +34,7 @@ namespace eudaq {
   }
 
   uint32_t DLLEXPORT str2hash(const std::string &stdstr);
-  std::vector<std::string> splitString(std::string str, char delimiter);
+  std::vector<std::string> DLLEXPORT splitString(std::string str, char delimiter);
 
   /** Sleep for a specified number of milliseconds.
    * \param ms The number of milliseconds


### PR DESCRIPTION
- updated a bit the Qt5 cmake
- will use by default Qt6 but will fall back to Qt 5.15 (last LTS)
- possible to force Qt5
- included in CI / ubuntu runner

