### PR TITLE
Add pybind for GetRunnumber in producer

### DIFF
--- a/main/lib/python/src/PybindProducer.cc
+++ b/main/lib/python/src/PybindProducer.cc
@@ -30,6 +30,11 @@ public:
 		      DoConfigure
 		      );
   }
+  int GetRunNumber() {
+    PYBIND11_OVERLOAD(int, /* Return type */
+                      eudaq::Producer, 
+                      GetRunNumber);
+  }
   void DoStartRun() override {
     PYBIND11_OVERLOAD(void, /* Return type */
 		      eudaq::Producer,
@@ -77,6 +82,7 @@ void init_pybind_producer(py::module &m){
   producer_.def(py::init([](const std::string &name,const std::string &runctrl){return PyProducer::Make("PyProducer", name, runctrl);}));
   producer_.def("SetStatusTag", &eudaq::Producer::SetStatusTag);
   producer_.def("SetStatusMsg", &eudaq::Producer::SetStatusMsg);
+  producer_.def("GetRunNumber", &eudaq::Producer::GetRunNumber);
   producer_.def("RunLoop", &eudaq::Producer::RunLoop);
   producer_.def("SendEvent", &eudaq::Producer::SendEvent,
   		"Send an Event", py::arg("ev"));


### PR DESCRIPTION
The Pybind for getting the runnumber was missing at the PybindProducer.cc file.

Added here.