### PR TITLE
Fix NOMINMAX for windows

### DIFF
--- a/main/exe/src/euCliReader.cxx
+++ b/main/exe/src/euCliReader.cxx
@@ -4,6 +4,10 @@
 
 #include <iostream>
 
+#ifdef max
+#undef max
+#endif
+
 int main(int /*argc*/, const char **argv) {
   eudaq::OptionParser op("EUDAQ Command Line FileReader modified for TLU", "2.1", "EUDAQ FileReader (TLU)");
   eudaq::Option<std::string> file_input(op, "i", "input", "", "string", "input file");

--- a/main/exe/src/euCliReader.cxx
+++ b/main/exe/src/euCliReader.cxx
@@ -4,10 +4,6 @@
 
 #include <iostream>
 
-#ifdef max
-#undef max
-#endif
-
 int main(int /*argc*/, const char **argv) {
   eudaq::OptionParser op("EUDAQ Command Line FileReader modified for TLU", "2.1", "EUDAQ FileReader (TLU)");
   eudaq::Option<std::string> file_input(op, "i", "input", "", "string", "input file");

--- a/main/lib/core/include/eudaq/Time.hh
+++ b/main/lib/core/include/eudaq/Time.hh
@@ -9,6 +9,7 @@
 
 #ifdef _WIN32
 #ifndef __CINT__
+#define NOMINMAX
 #include <winsock.h>
 #endif
 #else

--- a/main/lib/core/include/eudaq/TransportTCP.hh
+++ b/main/lib/core/include/eudaq/TransportTCP.hh
@@ -7,6 +7,7 @@
 
 #if EUDAQ_PLATFORM_IS(WIN32) || EUDAQ_PLATFORM_IS(MINGW)
 #ifndef __CINT__
+#define NOMINMAX
 #include <winsock.h> // using winsock2.h here would cause conflicts when including Windows4Root.h
                      // required e.g. by the ROOT online monitor
 #endif

--- a/main/lib/core/include/eudaq/TransportTCP_WIN32.hh
+++ b/main/lib/core/include/eudaq/TransportTCP_WIN32.hh
@@ -9,6 +9,7 @@
 #ifndef __CINT__
 // using winsock2.h here would cause conflicts when including Windows4Root.h
 // required e.g. by the ROOT online monitor
+#define NOMINAMAX
 #include <winsock.h>
 #endif
 

--- a/main/lib/core/src/ModuleManager.cc.in
+++ b/main/lib/core/src/ModuleManager.cc.in
@@ -20,6 +20,7 @@ namespace filesystem = @CXX_FILESYSTEM_NAMESPACE@;
 #endif
 
 #if EUDAQ_PLATFORM_IS(WIN32)
+#define NOMINMAX
 #include <windows.h>
 #include <intrin.h>
 #pragma intrinsic(_ReturnAddress)

--- a/monitors/onlinemon/include/SimpleStandardEvent.hh
+++ b/monitors/onlinemon/include/SimpleStandardEvent.hh
@@ -16,15 +16,8 @@ typedef char int8_t;
 #ifdef WIN32
 #define NOMINMAX
 #include <windows.h>
-typedef __int16 int16_t;
-typedef unsigned __int16 uint16_t;
-typedef __int32 int32_t;
-typedef unsigned __int32 uint32_t;
-typedef __int64 int64_t;
-typedef unsigned __int64 uint64_t;
-#else
-#include<cstdint>
 #endif
+#include<cstdint>
 #endif
 
 

--- a/monitors/onlinemon/include/SimpleStandardEvent.hh
+++ b/monitors/onlinemon/include/SimpleStandardEvent.hh
@@ -14,6 +14,7 @@ typedef char int8_t;
 
 #ifndef __CINT__
 #ifdef WIN32
+#define NOMINMAX
 #include <windows.h>
 typedef __int16 int16_t;
 typedef unsigned __int16 uint16_t;


### PR DESCRIPTION
euCliReader did not compile anymore on Windows. Not clear where windows.h gets pulled in now? Could be the boost from CMS? But should be isolated. This really should be cleaned up but it is a fix for the moment. Took the opportunity to clean up also some outdated root stuff.