### PR TITLE
Modernize StdEvtMonitor CMake

### DIFF
--- a/main/lib/core/include/eudaq/Utils.hh
+++ b/main/lib/core/include/eudaq/Utils.hh
@@ -165,6 +165,9 @@ namespace eudaq {
   from_string(const std::string &x, const uint16_t &def) {
     return static_cast<uint16_t>(from_string(x, (uint64_t)def));
   }
+  
+  template <>
+  bool DLLEXPORT from_string(const std::string &x, const bool &def);
 
   template <typename T> struct hexdec_t {
     enum { DIGITS = 2 * sizeof(T) };

--- a/main/lib/core/src/Utils.cc
+++ b/main/lib/core/src/Utils.cc
@@ -7,8 +7,11 @@
 #include <iostream>
 #include <cctype>
 
+#include <algorithm>
 #include <chrono>
+#include <string_view>
 #include <thread>
+#include <unordered_map>
 
 namespace eudaq {
   
@@ -136,6 +139,25 @@ namespace eudaq {
     if (!x.substr(end).empty())
       throw std::invalid_argument("Invalid argument: " + x);
     return result;
+  }
+  
+  template <> bool from_string(const std::string &x, const bool &def) {
+    if (x == "")
+      return def;
+    
+    static const std::unordered_map<std::string_view, bool> lookup = {
+        {"1", true}, {"true", true}, {"yes", true}, {"on", true},
+        {"0", false}, {"false", false}, {"no", false}, {"off", false}
+    };
+
+    std::string lowercase(x);
+    std::transform(lowercase.begin(), lowercase.end(), lowercase.begin(), ::tolower);
+
+    if (auto it = lookup.find(lowercase); it != lookup.end()) {
+        return it->second;
+    }
+    
+    throw std::invalid_argument("Invalid boolean string: " + std::string(x));
   }
 
   void WriteStringToFile(const std::string &fname, const std::string &val) {

--- a/monitors/onlinemon/CMakeLists.txt
+++ b/monitors/onlinemon/CMakeLists.txt
@@ -1,8 +1,3 @@
-if(WIN32)
-  message("StdEvent monitor is not to be built on windows")
-  return()
-endif()
-
 cmake_dependent_option(EUDAQ_BUILD_STDEVENT_MONITOR "monitor/StdEventMonitor executable (requires ROOT)" OFF
   "ROOT_FOUND" OFF)
 
@@ -12,15 +7,9 @@ if(NOT EUDAQ_BUILD_STDEVENT_MONITOR)
 endif()
 message(STATUS "monitor/StdEventMonitor is to be built (EUDAQ_BUILD_STDEVENT_MONITOR=ON)")
 
-if(WIN32)
-  find_package(ROOT REQUIRED COMPONENTS libGui libCore libHist libRIO)
-else()
-  find_package(ROOT REQUIRED COMPONENTS Gui)
-endif()
+find_package(ROOT REQUIRED COMPONENTS Core Gui Hist)
 
-include_directories(${ROOT_INCLUDE_DIR})
-include_directories(. include)
-include_directories(${CMAKE_BINARY_DIR})
+
 
 if(ROOT_VERSION_MAJOR GREATER 5)
   add_definitions(-DEUDAQ_LIB_ROOT6)
@@ -33,7 +22,8 @@ root_generate_dictionary(${THISMON}_ROOT include/OnlineMonWindow.hh)
 aux_source_directory(src THISMON_SRC)
 add_executable(${THISMON} ${THISMON_SRC} ${THISMON_DICT_CXX})
 
-target_link_libraries(${THISMON} ${EUDAQ_CORE_LIBRARY} ${ROOT_LIBRARIES})
+target_link_libraries(${THISMON} ${EUDAQ_CORE_LIBRARY} ROOT::Core ROOT::Gui ROOT::Hist)
+target_include_directories(${THISMON} PRIVATE . include)
 
 install(TARGETS ${THISMON}
   RUNTIME DESTINATION bin

--- a/monitors/onlinemon/CMakeLists.txt
+++ b/monitors/onlinemon/CMakeLists.txt
@@ -9,12 +9,6 @@ message(STATUS "monitor/StdEventMonitor is to be built (EUDAQ_BUILD_STDEVENT_MON
 
 find_package(ROOT REQUIRED COMPONENTS Core Gui Hist)
 
-
-
-if(ROOT_VERSION_MAJOR GREATER 5)
-  add_definitions(-DEUDAQ_LIB_ROOT6)
-endif()
-
 set(THISMON StdEventMonitor)
 set(THISMON_DICT_CXX ${CMAKE_CURRENT_BINARY_DIR}/${THISMON}_ROOT.cxx)
 root_generate_dictionary(${THISMON}_ROOT include/OnlineMonWindow.hh)

--- a/monitors/onlinemon/src/CorrelationHistos.cc
+++ b/monitors/onlinemon/src/CorrelationHistos.cc
@@ -131,11 +131,7 @@ CorrelationHistos::CorrelationHistos(SimpleStandardPlane p1,
     sprintf(out2, "h_corrVsTime_X_%s_%i_vs_%s_%i", _sensor1.c_str(), _id1,
             _sensor2.c_str(), _id2);
     _2dcorrTimeX = new TH2I(out2, out, 1000, 0, 1000, 200, 0, 10);
-#ifdef EUDAQ_LIB_ROOT6
     _2dcorrTimeX->SetCanExtend(TH2I::kAllAxes);
-#else
-    _2dcorrTimeX->SetBit(TH2I::kCanRebin);
-#endif
   }
   if (_maxY1 != -1 && _maxY2 != -1) {
     sprintf(out, "Y CorrelationVsTime of %s %i and %s %i", _sensor1.c_str(), _id1,
@@ -143,11 +139,7 @@ CorrelationHistos::CorrelationHistos(SimpleStandardPlane p1,
     sprintf(out2, "h_corrVsTime_Y_%s_%i_vs_%s_%i", _sensor1.c_str(), _id1,
             _sensor2.c_str(), _id2);
     _2dcorrTimeY = new TH2I(out2, out, 1000, 0, 1000, 200, 0, 10);
-#ifdef EUDAQ_LIB_ROOT6
     _2dcorrTimeY->SetCanExtend(TH2I::kAllAxes);
-#else
-    _2dcorrTimeY->SetBit(TH2I::kCanRebin);
-#endif
   }
   
   if (_maxX1 != -1 && _maxX2 != -1) {
@@ -156,11 +148,7 @@ CorrelationHistos::CorrelationHistos(SimpleStandardPlane p1,
     sprintf(out2, "h_corrVsTime_XY_%s_%i_vs_%s_%i", _sensor1.c_str(), _id1,
             _sensor2.c_str(), _id2);
     _2dcorrTimeXY = new TH2I(out2, out, 1000, 0, 1000, 200, 0, 10);
-#ifdef EUDAQ_LIB_ROOT6
     _2dcorrTimeXY->SetCanExtend(TH2I::kAllAxes);
-#else
-    _2dcorrTimeXY->SetBit(TH2I::kCanRebin);
-#endif
   }
   if (_maxY1 != -1 && _maxY2 != -1) {
     sprintf(out, "YX CorrelationVsTime of %s %i and %s %i", _sensor1.c_str(), _id1,
@@ -168,11 +156,7 @@ CorrelationHistos::CorrelationHistos(SimpleStandardPlane p1,
     sprintf(out2, "h_corrVsTime_YX_%s_%i_vs_%s_%i", _sensor1.c_str(), _id1,
             _sensor2.c_str(), _id2);
     _2dcorrTimeYX = new TH2I(out2, out, 1000, 0, 1000, 200, 0, 10);
-#ifdef EUDAQ_LIB_ROOT6
     _2dcorrTimeYX->SetCanExtend(TH2I::kAllAxes);
-#else
-    _2dcorrTimeYX->SetBit(TH2I::kCanRebin);
-#endif
   }  
 
 }

--- a/monitors/onlinemon/src/EUDAQMonitorHistos.cc
+++ b/monitors/onlinemon/src/EUDAQMonitorHistos.cc
@@ -28,13 +28,8 @@ EUDAQMonitorHistos::EUDAQMonitorHistos(const SimpleStandardEvent &ev) {
   m_EventN_vs_TimeStamp->GetYaxis()->SetTitle("event number");
 
   
-#ifdef EUDAQ_LIB_ROOT6
   Hits_vs_EventsTotal->SetCanExtend(TH1::kAllAxes);
   TracksPerEvent->SetCanExtend(TH1::kAllAxes);
-#else
-  Hits_vs_EventsTotal->SetBit(TH1::kCanRebin);
-  TracksPerEvent->SetBit(TH1::kCanRebin);
-#endif
   
   for (unsigned int i = 0; i < nplanes; i++) {
 
@@ -57,11 +52,7 @@ EUDAQMonitorHistos::EUDAQMonitorHistos(const SimpleStandardEvent &ev) {
       Hits_vs_Events[i]->SetMarkerColor(i + 2);
     }
 
-#ifdef EUDAQ_LIB_ROOT6
     Hits_vs_Events[i]->SetCanExtend(TH1::kAllAxes);
-#else
-    Hits_vs_Events[i]->SetBit(TH1::kCanRebin);
-#endif
   }
 }
 

--- a/monitors/onlinemon/src/HitmapHistos.cc
+++ b/monitors/onlinemon/src/HitmapHistos.cc
@@ -101,11 +101,7 @@ HitmapHistos::HitmapHistos(SimpleStandardPlane p, RootMonitor *mon)
       _totSingle = new TH1I(out2, out, 255, -127, 127);
     } else {
       _totSingle = new TH1I(out2, out, 256, 0, 255);
-#ifdef EUDAQ_LIB_ROOT6
       _totSingle->SetCanExtend(TH1::kAllAxes);
-#else
-      _totSingle->SetBit(TH1::kCanRebin);
-#endif
     }
 
     sprintf(out, "%s %i TOT Clusters", _sensor.c_str(), _id);


### PR DESCRIPTION
- target based cmake handling of ROOT linking
- added template specialization of from_string<bool> utility function which made it fail on Windows
- remove ROOT5 compatibility