### PR TITLE
Fix core build target and depending header paths

### DIFF
--- a/main/lib/core/CMakeLists.txt
+++ b/main/lib/core/CMakeLists.txt
@@ -19,8 +19,6 @@ set(EUDAQ_INCLUDE_DIRS
   CACHE INTERNAL "directory of eudaq include")
 
 
-include_directories(include)
-include_directories(include/eudaq)
 
 aux_source_directory(src CORE_SRC)
 list(APPEND CORE_SRC ${CMAKE_CURRENT_BINARY_DIR}/ModuleManager.cc)
@@ -55,7 +53,7 @@ IF(ROOT_FOUND)
       ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}${EUDAQ_CORE_LIBRARY}.rootmap
       DESTINATION lib)
 ENDIF()
-
+	
 set_target_properties(${EUDAQ_CORE_LIBRARY} PROPERTIES DEFINE_SYMBOL "core_EXPORTS" )
 set_target_properties(${EUDAQ_CORE_LIBRARY} PROPERTIES VERSION ${EUDAQ_VERSION_MAJOR}.${EUDAQ_VERSION_MINOR})
 set_target_properties(${EUDAQ_CORE_LIBRARY} PROPERTIES EXPORT_NAME ${EUDAQ_TARGET})

--- a/main/lib/core/CMakeLists.txt
+++ b/main/lib/core/CMakeLists.txt
@@ -67,7 +67,7 @@ configure_file(src/ModuleManager.cc.in ModuleManager.cc @ONLY)
 
 list(APPEND ADDITIONAL_LIBRARIES ${CMAKE_DL_LIBS})
 target_link_libraries(${EUDAQ_CORE_LIBRARY} PUBLIC ${EUDAQ_THREADS_LIB} PRIVATE ${ADDITIONAL_LIBRARIES})
-target_include_directories(${EUDAQ_CORE_LIBRARY} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<INSTALL_INTERFACE:include>)
+target_include_directories(${EUDAQ_CORE_LIBRARY} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>/include $<INSTALL_INTERFACE:include>)
 
 install(TARGETS ${EUDAQ_CORE_LIBRARY}
   EXPORT eudaqTargets

--- a/main/lib/core/include/eudaq/Exception.hh
+++ b/main/lib/core/include/eudaq/Exception.hh
@@ -4,7 +4,7 @@
 #include "eudaq/Utils.hh"
 #include <exception>
 #include <string>
-#include "Platform.hh"
+#include "eudaq/Platform.hh"
 
 #ifndef EUDAQ_FUNC
 #define EUDAQ_FUNC ""

--- a/main/lib/core/include/eudaq/Time.hh
+++ b/main/lib/core/include/eudaq/Time.hh
@@ -1,7 +1,7 @@
 #ifndef EUDAQ_INCLUDED_Time
 #define EUDAQ_INCLUDED_Time
 
-#include "Platform.hh"
+#include "eudaq/Platform.hh"
 #include <ostream>
 #include <iomanip>
 #include <string>

--- a/main/lib/core/include/eudaq/Utils.hh
+++ b/main/lib/core/include/eudaq/Utils.hh
@@ -9,7 +9,7 @@
 #include <stdexcept>
 #include <fstream>
 
-#include "Platform.hh"
+#include "eudaq/Platform.hh"
 
 namespace eudaq {
 

--- a/main/lib/core/src/FileWriter.cc
+++ b/main/lib/core/src/FileWriter.cc
@@ -1,6 +1,6 @@
-#include "FileWriter.hh"
-#include "FileNamer.hh"
-#include "Exception.hh"
+#include "eudaq/FileWriter.hh"
+#include "eudaq/FileNamer.hh"
+#include "eudaq/Exception.hh"
 
 namespace eudaq {
 

--- a/main/lib/core/src/Processor.cc
+++ b/main/lib/core/src/Processor.cc
@@ -1,5 +1,5 @@
-#include "Processor.hh"
-#include "Utils.hh"
+#include "eudaq/Processor.hh"
+#include "eudaq/Utils.hh"
 
 using namespace eudaq;
 

--- a/main/lib/core/src/Serializable.cc
+++ b/main/lib/core/src/Serializable.cc
@@ -1,4 +1,4 @@
-#include "Serializable.hh"
+#include "eudaq/Serializable.hh"
 
 namespace eudaq {
   

--- a/main/lib/core/src/TransportTCP.cc
+++ b/main/lib/core/src/TransportTCP.cc
@@ -48,10 +48,10 @@ at some places we have constructions like:
 #include <iostream>
 
 #if EUDAQ_PLATFORM_IS(WIN32) || EUDAQ_PLATFORM_IS(MINGW)
-#include "TransportTCP_WIN32.hh"
+#include "eudaq/TransportTCP_WIN32.hh"
 #pragma comment(lib, "Ws2_32.lib")
 #else
-#include "TransportTCP_POSIX.hh"
+#include "eudaq/TransportTCP_POSIX.hh"
 #endif
 
 // print debug messages that are optimized out if DEBUG_TRANSPORT is not set:


### PR DESCRIPTION
In the build path of the eudaq_core target the /include is missing which makes inclusion in down stream projects impossible without workarounds. Fixing also the paths after removing the non-target include. (There are still more cmake style violations to be fixed but trying to keep in concise.)