### PR TITLE
Adapting Caribou modules to new Peary architecture

### DIFF
--- a/main/lib/core/CMakeLists.txt
+++ b/main/lib/core/CMakeLists.txt
@@ -47,7 +47,7 @@ IF(ROOT_FOUND)
     COMPILE_FLAGS  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:"-Wno-unused-function -Wno-overlength-strings -Wno-zero-as-null-pointer-constant -w -I${CMAKE_CURRENT_SOURCE_DIR}">
     )
 
-  TARGET_LINK_LIBRARIES(${EUDAQ_CORE_LIBRARY} ROOT::Core)
+  TARGET_LINK_LIBRARIES(${EUDAQ_CORE_LIBRARY} PUBLIC ROOT::Core)
 
   # Also install the dictionary objects
   INSTALL(FILES
@@ -66,7 +66,7 @@ endif()
 configure_file(src/ModuleManager.cc.in ModuleManager.cc @ONLY)
 
 list(APPEND ADDITIONAL_LIBRARIES ${CMAKE_DL_LIBS})
-target_link_libraries(${EUDAQ_CORE_LIBRARY} ${EUDAQ_THREADS_LIB} ${ADDITIONAL_LIBRARIES})
+target_link_libraries(${EUDAQ_CORE_LIBRARY} PUBLIC ${EUDAQ_THREADS_LIB} PRIVATE ${ADDITIONAL_LIBRARIES})
 target_include_directories(${EUDAQ_CORE_LIBRARY} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<INSTALL_INTERFACE:include>)
 
 install(TARGETS ${EUDAQ_CORE_LIBRARY}

--- a/user/caribou/module/CMakeLists.txt
+++ b/user/caribou/module/CMakeLists.txt
@@ -12,6 +12,7 @@ endif()
 
 if(NOT ROOT_FOUND)
   list(REMOVE_ITEM MODULE_SRC src/AD9249EventConverter.cc)
+  list(REMOVE_ITEM MODULE_SRC src/DSO9254AEventConverter.cc)
 endif()
 
 ADD_LIBRARY(${EUDAQ_MODULE} SHARED ${MODULE_SRC})

--- a/user/caribou/module/CMakeLists.txt
+++ b/user/caribou/module/CMakeLists.txt
@@ -16,7 +16,7 @@ endif()
 
 ADD_LIBRARY(${EUDAQ_MODULE} SHARED ${MODULE_SRC})
 TARGET_LINK_LIBRARIES(${EUDAQ_MODULE} PUBLIC ${EUDAQ_CORE_LIBRARY})
-target_link_libraries(${EUDAQ_MODULE} PRIVATE Peary::peary Peary::devices)
+target_link_libraries(${EUDAQ_MODULE} PRIVATE Caribou::peary Caribou::devices)
 
 IF(ROOT_FOUND)
   TARGET_LINK_LIBRARIES(${EUDAQ_MODULE} PUBLIC ${ROOT_LIBRARIES})

--- a/user/caribou/module/CMakeLists.txt
+++ b/user/caribou/module/CMakeLists.txt
@@ -16,7 +16,7 @@ endif()
 
 ADD_LIBRARY(${EUDAQ_MODULE} SHARED ${MODULE_SRC})
 TARGET_LINK_LIBRARIES(${EUDAQ_MODULE} PUBLIC ${EUDAQ_CORE_LIBRARY})
-target_link_libraries(${EUDAQ_MODULE} PRIVATE Caribou::peary Caribou::devices)
+target_link_libraries(${EUDAQ_MODULE} PRIVATE Peary::peary Peary::devices)
 
 IF(ROOT_FOUND)
   TARGET_LINK_LIBRARIES(${EUDAQ_MODULE} PUBLIC ${ROOT_LIBRARIES})

--- a/user/caribou/module/include/CaribouEvent2StdEventConverter.hh
+++ b/user/caribou/module/include/CaribouEvent2StdEventConverter.hh
@@ -3,7 +3,7 @@
 #include "eudaq/Logger.hh"
 #include <set>
 #include "utils/datatypes.hpp"
-#include "utils/log.hpp"
+#include "log/log.hpp"
 #include "utils/utils.hpp"
 #include <array>
 #include <vector>
@@ -107,7 +107,7 @@ namespace eudaq {
 
     // convert a data blocks to waveforms
     static std::vector<std::vector<waveform>>
-    read_data(caribou::pearyRawData &rawdata, int evt, uint64_t & block_position, int n_channels);
+    read_data(peary::utils::pearyRawData &rawdata, int evt, uint64_t & block_position, int n_channels);
     // get the trigger number from the digital waveforns. This is tailored to the AIDA TLU operating in the AIDA+trigerID mode
     static std::vector<uint64_t> calc_triggers(std::vector<waveform> &waves);
     // parse the channel mapping from string

--- a/user/caribou/module/src/AD9249EventConverter.cc
+++ b/user/caribou/module/src/AD9249EventConverter.cc
@@ -1,6 +1,6 @@
 #include "CaribouEvent2StdEventConverter.hh"
 
-#include "utils/log.hpp"
+#include "log/log.hpp"
 
 #include <algorithm>
 #include <fstream>

--- a/user/caribou/module/src/ATLASPixEventConverter.cc
+++ b/user/caribou/module/src/ATLASPixEventConverter.cc
@@ -1,5 +1,5 @@
 #include "CaribouEvent2StdEventConverter.hh"
-#include "utils/log.hpp"
+#include "log/log.hpp"
 
 using namespace eudaq;
 

--- a/user/caribou/module/src/CLICTDEventConverter.cc
+++ b/user/caribou/module/src/CLICTDEventConverter.cc
@@ -1,10 +1,13 @@
 #include "CaribouEvent2StdEventConverter.hh"
 
 #include <devices/CLICTD/CLICTDFrameDecoder.hpp>
-#include <peary/utils/log.hpp>
+#include <peary/log/log.hpp>
 #include <devices/CLICTD/CLICTDPixels.hpp>
 
 using namespace eudaq;
+using namespace peary::utils;
+using namespace peary::dut;
+using namespace peary::device;
 
 namespace{
   auto dummy0 = eudaq::Factory<eudaq::StdEventConverter>::
@@ -27,7 +30,7 @@ bool CLICTDEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Standa
   auto discard_tot_below = conf->Get("discard_tot_below", -1);
   auto discard_toa_below = conf->Get("discard_toa_below", -1);
 
-  static caribou::CLICTDFrameDecoder decoder(longcnt);
+  static CLICTDFrameDecoder decoder(longcnt);
   // No event
   if(!ev) {
     return false;
@@ -35,7 +38,7 @@ bool CLICTDEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Standa
 
   // Data containers:
   std::vector<uint64_t> timestamps;
-  caribou::pearyRawData rawdata;
+  pearyRawData rawdata;
 
   // Retrieve data from event
   if(ev->NumBlocks() == 1) {
@@ -235,7 +238,7 @@ bool CLICTDEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Standa
 
   plane.SetSizeZS(128, 128, 0);
   for(const auto& px : data) {
-    auto pixel = dynamic_cast<caribou::CLICTDPixelReadout*>(px.second.get());
+    auto pixel = dynamic_cast<CLICTDPixelReadout*>(px.second.get());
 
     // Disentangle data types from pixel:
     int tot = -1;
@@ -248,7 +251,7 @@ bool CLICTDEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Standa
       if(tot < discard_tot_below) {
         continue;
       }
-    } catch(caribou::DataException&) {
+    } catch(DataTakingError&) {
       // Set ToT to one if not defined.
       tot = 1;
     }

--- a/user/caribou/module/src/CLICTDEventConverter.cc
+++ b/user/caribou/module/src/CLICTDEventConverter.cc
@@ -251,7 +251,7 @@ bool CLICTDEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Standa
       if(tot < discard_tot_below) {
         continue;
       }
-    } catch(DataTakingError&) {
+    } catch(DataAcquisitionError&) {
       // Set ToT to one if not defined.
       tot = 1;
     }

--- a/user/caribou/module/src/CLICpix2EventConverter.cc
+++ b/user/caribou/module/src/CLICpix2EventConverter.cc
@@ -179,7 +179,7 @@ bool CLICpix2Event2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Stan
       if(tot < discard_tot_below) {
         continue;
       }
-    } catch(DataTakingError&) {
+    } catch(DataAcquisitionError&) {
       // Set ToT to one if not defined.
       tot = 1;
     }

--- a/user/caribou/module/src/CLICpix2EventConverter.cc
+++ b/user/caribou/module/src/CLICpix2EventConverter.cc
@@ -1,10 +1,13 @@
 #include "CaribouEvent2StdEventConverter.hh"
 
 #include <devices/CLICpix2/framedecoder/clicpix2_frameDecoder.hpp>
-#include <peary/utils/log.hpp>
+#include <peary/log/log.hpp>
 #include <devices/CLICpix2/clicpix2_pixels.hpp>
 
 using namespace eudaq;
+using namespace peary::device;
+using namespace peary::dut;
+using namespace peary::utils;
 
 namespace{
   auto dummy0 = eudaq::Factory<eudaq::StdEventConverter>::
@@ -28,18 +31,18 @@ bool CLICpix2Event2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Stan
 
   // Prepare matrix decoder:
   static auto matrix_config = [counting, longcnt]() {
-    std::map<std::pair<uint8_t, uint8_t>, caribou::pixelConfig> matrix;
+    std::map<std::pair<uint8_t, uint8_t>, pixelConfig> matrix;
     for(uint8_t x = 0; x < 128; x++) {
       for(uint8_t y = 0; y < 128; y++) {
         // FIXME hard-coded matrix configuration for CLICpix2 - needs to be read from a configuration!
-        matrix[std::make_pair(y,x)] = caribou::pixelConfig(true, 3, counting, false, longcnt);
+        matrix[std::make_pair(y,x)] = pixelConfig(true, 3, counting, false, longcnt);
       }
     }
     return matrix;
   };
 
   static auto matrix = matrix_config();
-  static caribou::clicpix2_frameDecoder decoder(comp, sp_comp, matrix);
+  static clicpix2_frameDecoder decoder(comp, sp_comp, matrix);
   // No event
   if(!ev) {
     return false;
@@ -161,7 +164,7 @@ bool CLICpix2Event2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Stan
 
   plane.SetSizeZS(128, 128, 0);
   for(const auto& px : data) {
-    auto cp2_pixel = dynamic_cast<caribou::pixelReadout*>(px.second.get());
+    auto cp2_pixel = dynamic_cast<pixelReadout*>(px.second.get());
     int col = px.first.first;
     int row = px.first.second;
 
@@ -176,7 +179,7 @@ bool CLICpix2Event2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Stan
       if(tot < discard_tot_below) {
         continue;
       }
-    } catch(caribou::DataException&) {
+    } catch(DataTakingError&) {
       // Set ToT to one if not defined.
       tot = 1;
     }

--- a/user/caribou/module/src/CaribouProducer.cxx
+++ b/user/caribou/module/src/CaribouProducer.cxx
@@ -289,7 +289,7 @@ void CaribouProducer::RunLoop() {
       }
 
       LOG_PROGRESS(STATUS, "status") << "Frame " << m_ev;
-    } catch(DataTakingError& e) {
+    } catch(DataAcquisitionError& e) {
       // Retrieval failed, retry once more before aborting:
       EUDAQ_WARN(std::string(e.what()) + ", skipping data packet");
       continue;

--- a/user/caribou/module/src/CaribouProducer.cxx
+++ b/user/caribou/module/src/CaribouProducer.cxx
@@ -2,13 +2,16 @@
 #include "eudaq/Configuration.hh"
 
 #include "peary/device/DeviceManager.hpp"
-#include "peary/utils/configuration.hpp"
-#include "peary/utils/log.hpp"
+#include "peary/config/configuration.hpp"
+#include "peary/log/log.hpp"
 
 #include <vector>
 #include <thread>
 
-using namespace caribou;
+using namespace peary::config;
+using namespace peary::device;
+using namespace peary::log;
+using namespace peary::utils;
 
 class CaribouProducer : public eudaq::Producer {
 public:
@@ -90,14 +93,14 @@ void CaribouProducer::DoInitialise() {
     LogLevel log_level = Log::getLevelFromString(level);
     Log::setReportingLevel(log_level);
     LOG(INFO) << "Set verbosity level to \"" << std::string(level) << "\"";
-  } catch(std::invalid_argument& e) {
+  } catch(InvalidArgumentError& e) {
     LOG(ERROR) << "Invalid verbosity level \"" << std::string(level) << "\", ignoring.";
   }
 
   level_ = Log::getReportingLevel();
 
   // Open configuration file and create object:
-  caribou::ConfigParser cfg;
+  ConfigParser cfg;
   auto confname = ini->Get("config_file", "");
   std::ifstream file(confname);
   EUDAQ_INFO("Attempting to use initial device configuration \"" + confname + "\"");
@@ -105,7 +108,7 @@ void CaribouProducer::DoInitialise() {
     LOG(ERROR) << "No configuration file provided.";
     EUDAQ_ERROR("No Caribou configuration file provided.");
   } else {
-    cfg = caribou::ConfigParser(file);
+    cfg = ConfigParser(file);
   }
 
   // Select section from the configuration file relevant for this device:
@@ -175,7 +178,7 @@ void CaribouProducer::DoConfigure() {
 
   if(!adc_signal_.empty()) {
     // Try it out directly to catch misconfiugration
-    auto adc_value = device_->getADC(adc_signal_);
+    auto adc_value = device_->getVoltage(adc_signal_);
     EUDAQ_USER("Will probe ADC signal \"" + adc_signal_ + "\" every " + std::to_string(adc_freq_) + " events");
   }
 
@@ -256,7 +259,7 @@ void CaribouProducer::RunLoop() {
         // Query ADC if wanted:
         if(m_ev%adc_freq_ == 0) {
           if(!adc_signal_.empty()) {
-            auto adc_value = device_->getADC(adc_signal_);
+            auto adc_value = device_->getVoltage(adc_signal_);
             LOG(DEBUG) << "Reading ADC: " << adc_value << "V";
             EUDAQ_USER("ADC reading: " + adc_signal_ + " =  " + std::to_string(adc_value));
             event->SetTag(adc_signal_, adc_value);
@@ -286,13 +289,11 @@ void CaribouProducer::RunLoop() {
       }
 
       LOG_PROGRESS(STATUS, "status") << "Frame " << m_ev;
-    } catch(caribou::NoDataAvailable&) {
-        continue;
-    } catch(caribou::DataException& e) {
+    } catch(DataTakingError& e) {
       // Retrieval failed, retry once more before aborting:
       EUDAQ_WARN(std::string(e.what()) + ", skipping data packet");
       continue;
-    } catch(caribou::caribouException& e) {
+    } catch(Exception& e) {
       EUDAQ_ERROR(e.what());
       break;
     }

--- a/user/caribou/module/src/DSO9254AEventConverter.cc
+++ b/user/caribou/module/src/DSO9254AEventConverter.cc
@@ -3,10 +3,11 @@
 #include "TGraph.h"
 #include "TH1D.h"
 #include "time.h"
-#include "utils/log.hpp"
+#include "log/log.hpp"
 #include <sstream>
 
 using namespace eudaq;
+using namespace peary::utils;
 
 namespace {
   auto dummy0 = eudaq::Factory<eudaq::StdEventConverter>::Register<
@@ -89,7 +90,7 @@ bool DSO9254AEvent2StdEventConverter::Converting(
   } // configure
 
   // Data container:
-  caribou::pearyRawData rawdata;
+  pearyRawData rawdata;
 
   // internal containers
   uint64_t timestamp;
@@ -201,7 +202,7 @@ bool DSO9254AEvent2StdEventConverter::Converting(
 // return the vectors of waveform objects (size given by number of segments) for
 // each active channesl
 std::vector<std::vector<waveform>>
-DSO9254AEvent2StdEventConverter::read_data(caribou::pearyRawData &rawdata,
+DSO9254AEvent2StdEventConverter::read_data(pearyRawData &rawdata,
                                            int evt, uint64_t &block_position,
                                            int n_channels) {
 

--- a/user/caribou/module/src/H2MEventConverter.cc
+++ b/user/caribou/module/src/H2MEventConverter.cc
@@ -118,7 +118,7 @@ bool H2MEvent2StdEventConverter::Converting(
   try{
     frame = decoder.decodeFrame<uint32_t>(rawdata, acq_mode);
   }
-  catch(DataTakingError&){
+  catch(DataAcquisitionError&){
     EUDAQ_ERROR("H2M decoder failed!");
     EUDAQ_ERROR("Length of rawdata (should be 262): " +to_string(rawdata.size()));
     return false;

--- a/user/caribou/module/src/H2MEventConverter.cc
+++ b/user/caribou/module/src/H2MEventConverter.cc
@@ -3,13 +3,16 @@
 
 #include <devices/H2M/H2MFrameDecoder.hpp>
 #include <devices/H2M/h2m_pixels.hpp>
-#include <peary/utils/log.hpp>
+#include <peary/log/log.hpp>
 
 #include <string>
 #include <algorithm>
 #include <cmath>
 
 using namespace eudaq;
+using namespace peary::dut;
+using namespace peary::utils;
+using namespace peary::device;
 
 namespace {
   auto dummy0 = eudaq::Factory<eudaq::StdEventConverter>::Register<
@@ -53,7 +56,7 @@ bool H2MEvent2StdEventConverter::Converting(
   }
 
   // get an instance of the frame decoder
-  static caribou::H2MFrameDecoder decoder;
+  static H2MFrameDecoder decoder;
 
   // Data container:
   std::vector<uint32_t> rawdata;
@@ -111,11 +114,11 @@ bool H2MEvent2StdEventConverter::Converting(
   rawdata.erase(rawdata.begin(),rawdata.begin()+6);
 
   // Decode the event raw data - no zero suppression
-  caribou::pearydata frame;
+  pearydata frame;
   try{
     frame = decoder.decodeFrame<uint32_t>(rawdata, acq_mode);
   }
-  catch(caribou::DataCorrupt&){
+  catch(DataTakingError&){
     EUDAQ_ERROR("H2M decoder failed!");
     EUDAQ_ERROR("Length of rawdata (should be 262): " +to_string(rawdata.size()));
     return false;
@@ -137,7 +140,7 @@ bool H2MEvent2StdEventConverter::Converting(
     auto [col, row] = pixel.first;
 
     // cast into right type of pixel and retrieve stored data
-    auto pixHit = dynamic_cast<caribou::h2m_pixel_readout *>(pixel.second.get());
+    auto pixHit = dynamic_cast<h2m_pixel_readout *>(pixel.second.get());
 
     // Pixel value of whatever equals zero means: no hit
     if(pixHit->GetData() == 0) {
@@ -147,7 +150,7 @@ bool H2MEvent2StdEventConverter::Converting(
     // Fetch timestamp from pixel if on ToA mode,
     // otherwise set to frame center (CERN mode) or configure a position with respect to the frame end (in ps, DESY mode)
     uint64_t not_toa_time = delay_to_frame_end > 0 ? frameEnd - delay_to_frame_end : ((frameStart + frameEnd) / 2);
-    uint64_t timestamp = pixHit->GetMode() == caribou::ACQ_MODE_TOA ? (frameEnd - (pixHit->GetToA() * _100MHz_to_ps)) : not_toa_time;
+    uint64_t timestamp = pixHit->GetMode() == ACQ_MODE_TOA ? (frameEnd - (pixHit->GetToA() * _100MHz_to_ps)) : not_toa_time;
     uint64_t tot = pixHit->GetToT();
 
     // best guess for charge is ToT if no calibration is available

--- a/user/caribou/module/src/dSiPMEventConverter.cc
+++ b/user/caribou/module/src/dSiPMEventConverter.cc
@@ -4,12 +4,13 @@
 
 #include <devices/dSiPM/dSiPMFrameDecoder.hpp>
 #include <devices/dSiPM/dSiPMPixels.hpp>
-#include <peary/utils/log.hpp>
+#include <peary/log/log.hpp>
 
 #include <string>
 #include <algorithm>
 
 using namespace eudaq;
+using namespace peary::dut;
 
 namespace {
   auto dummy0 = eudaq::Factory<eudaq::StdEventConverter>::Register<
@@ -77,7 +78,7 @@ bool dSiPMEvent2StdEventConverter::Converting(
   }
 
   // get an instance of the frame decoder
-  static caribou::dSiPMFrameDecoder decoder;
+  static dSiPMFrameDecoder decoder;
 
   // Data container:
   std::vector<uint32_t> rawdata;
@@ -143,7 +144,7 @@ bool dSiPMEvent2StdEventConverter::Converting(
     auto row = pixel.first.second;
     auto quad = getQuadrant(col, row);
     // cast into right type of pixel and retrieve stored data
-    auto ds_pix = dynamic_cast<caribou::dsipm_pixel *>(pixel.second.get());
+    auto ds_pix = dynamic_cast<dsipm_pixel *>(pixel.second.get());
     // binary hit information
     auto hitBit = ds_pix->getBit();
     // valid bit


### PR DESCRIPTION
This MR adapt all EUDAQ Caribou modules to the new Peary architecture located in the [Peary `main` branch](https://gitlab.cern.ch/Caribou/peary/-/tree/main). It includes:

- fix of the main/lib/core/CMakeLists `target_link_libraries` signature style for ROOT::core as it was failing compilation. Please double check @lhuth @simonspa 
- correction of headers path following a change in the Peary repository structure
- adaptation of namespace usage following an expansion of the Peary namespace structure
- adaptation of handled exceptions following a change in the Peary exception structure