### PR TITLE
CI Update

### DIFF
--- a/.github/workflows/build-linux-clang.yml
+++ b/.github/workflows/build-linux-clang.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         qt_version: [5, 6]
         compiler: [clang-latest]
-        cpp_standard: [17, 20]
+        cpp_standard: [17, 20, 23]
         
     name: eudaq_full_build-ubuntu-latest-${{matrix.compiler}}-cxx_standard-${{matrix.cpp_standard}}-qt-${{matrix.qt_version}}
 

--- a/.github/workflows/build-linux-clang.yml
+++ b/.github/workflows/build-linux-clang.yml
@@ -60,7 +60,7 @@ jobs:
 
     - name: restore CERN ROOT from cache
       id: root_restore_from_cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: ~/eudaq_dependencies/root
         key: root-v6.38.00-${{ runner.os }}-${{ steps.install_cc.outputs.cxx }}-${{matrix.cpp_standard}}
@@ -87,7 +87,7 @@ jobs:
         
     - name: cache CERN ROOT
       id: root_save_to_cache
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       if: steps.root_restore_from_cache.outputs.cache-hit != 'true'
       with:
         path: |

--- a/.github/workflows/build-linux-clang.yml
+++ b/.github/workflows/build-linux-clang.yml
@@ -25,7 +25,7 @@ jobs:
     name: eudaq_full_build-ubuntu-latest-${{matrix.compiler}}-cxx_standard-${{matrix.cpp_standard}}-qt-${{matrix.qt_version}}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     
     - name: update repo
       run: |

--- a/.github/workflows/build-linux-gcc.yml
+++ b/.github/workflows/build-linux-gcc.yml
@@ -28,7 +28,7 @@ jobs:
     name: eudaq_full_build-ubuntu-latest-${{matrix.compiler}}-cxx_standard-${{matrix.cpp_standard}}-qt-${{matrix.qt_version}}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     
     - name: update repo
       run: |

--- a/.github/workflows/build-linux-gcc.yml
+++ b/.github/workflows/build-linux-gcc.yml
@@ -63,7 +63,7 @@ jobs:
         
     - name: restore CERN ROOT from cache
       id: root_restore_from_cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: ~/eudaq_dependencies/root
         key: root-v6.38.00-${{ runner.os }}-${{ steps.install_cc.outputs.cxx }}-${{matrix.cpp_standard}}
@@ -90,7 +90,7 @@ jobs:
         
     - name: cache CERN ROOT
       id: root_save_to_cache
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       if: steps.root_restore_from_cache.outputs.cache-hit != 'true'
       with:
         path: |

--- a/.github/workflows/build-linux-gcc.yml
+++ b/.github/workflows/build-linux-gcc.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         qt_version: [5, 6]
         compiler: [gcc-latest]
-        cpp_standard: [17, 20]
+        cpp_standard: [17, 20, 23]
         
     name: eudaq_full_build-ubuntu-latest-${{matrix.compiler}}-cxx_standard-${{matrix.cpp_standard}}-qt-${{matrix.qt_version}}
 

--- a/.github/workflows/build-macos-clang.yml
+++ b/.github/workflows/build-macos-clang.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-15, macos-14]
-        qt_version: [5, 6]
+        qt_version: [6]
 
     name: eudaq_full_build-${{matrix.os}}-apple-clang-qt-${{matrix.qt_version}}
 

--- a/.github/workflows/build-macos-clang.yml
+++ b/.github/workflows/build-macos-clang.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-15, macos-14]
+        os: [macos-26, macos-26-intel, macos-15, macos-14]
         qt_version: [6]
 
     name: eudaq_full_build-${{matrix.os}}-apple-clang-qt-${{matrix.qt_version}}

--- a/.github/workflows/build-macos-clang.yml
+++ b/.github/workflows/build-macos-clang.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-26, macos-26-intel, macos-15, macos-14]
+        os: [macos-26, macos-15, macos-14]
         qt_version: [6]
 
     name: eudaq_full_build-${{matrix.os}}-apple-clang-qt-${{matrix.qt_version}}

--- a/.github/workflows/build-macos-clang.yml
+++ b/.github/workflows/build-macos-clang.yml
@@ -31,7 +31,7 @@ jobs:
     name: eudaq_full_build-${{matrix.os}}-apple-clang-qt-${{matrix.qt_version}}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: install xrootd
         run: |

--- a/.github/workflows/build-windows-vs.yml
+++ b/.github/workflows/build-windows-vs.yml
@@ -38,7 +38,7 @@ jobs:
     name: eudaq_full_build-windows-latest-${{matrix.compiler}}-${{matrix.arch}}-qt-${{matrix.qt_version}}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     
     - uses: ilammy/msvc-dev-cmd@v1
       with:


### PR DESCRIPTION
Change download action version from v4 to v6 as node 20 will be depreciated on the runners in June 2026. Add C++23 run. Remove qt5 for MacOS and add MacOS 26 intel/arm.