### PR TITLE
Use std::numeric_limits for maximum values

### DIFF
--- a/user/example/module/src/Ex0TgDataCollector.cc
+++ b/user/example/module/src/Ex0TgDataCollector.cc
@@ -4,6 +4,7 @@
 #include <deque>
 #include <map>
 #include <set>
+#include <limits>
 
 class Ex0TgDataCollector:public eudaq::DataCollector{
 public:
@@ -72,7 +73,7 @@ void Ex0TgDataCollector::DoReceive(eudaq::ConnectionSPC idx, eudaq::EventSP evsp
   }
   m_conn_evque[idx].push_back(evsp);
 
-  uint32_t trigger_n = -1;
+  uint32_t trigger_n = std::numeric_limits<uint32_t>::max();
   for(auto &conn_evque: m_conn_evque){
     if(conn_evque.second.empty())
       return;

--- a/user/example/module/src/Ex0TgTsDataCollector.cc
+++ b/user/example/module/src/Ex0TgTsDataCollector.cc
@@ -4,6 +4,7 @@
 #include <deque>
 #include <map>
 #include <set>
+#include <limits>
 
 //----------DOC-MARK-----BEG*DEC-----DOC-MARK----------
 class Ex0TgTsDataCollector:public eudaq::DataCollector{
@@ -300,7 +301,7 @@ void Ex0TgTsDataCollector::BuildEvent_TimeStamp(){
   std::cout<< "m_que_event_ts.size() "<< m_que_event_ts.size()<<std::endl;
   while(!m_event_ready_ts.empty() && m_event_ready_ts.size() == m_que_event_ts.size()){
     std::cout<<"ts building main, loop\n";
-    uint64_t ts_next_end = -1;
+    uint64_t ts_next_end = std::numeric_limits<uint64_t>::max();
     uint64_t ts_next_beg = ts_next_end - 1;
     auto ev_wrap = eudaq::Event::MakeUnique(GetFullName());
     ev_wrap->SetTimestamp(m_ts_curr_beg, m_ts_curr_end);

--- a/user/example/module/src/Ex0TsDataCollector.cc
+++ b/user/example/module/src/Ex0TsDataCollector.cc
@@ -3,6 +3,7 @@
 #include <deque>
 #include <map>
 #include <set>
+#include <limits>
 
 //----------DOC-MARK-----BEG*DEC-----DOC-MARK----------
 class Ex0TsDataCollector:public eudaq::DataCollector{
@@ -106,7 +107,7 @@ void Ex0TsDataCollector::DoReceive(eudaq::ConnectionSPC idx, eudaq::EventSP evsp
 
 void Ex0TsDataCollector::BuildEvent(){
   while(!m_event_ready_ts.empty() && m_event_ready_ts.size() == m_que_event_ts.size()){
-    uint64_t ts_next_end = -1;
+    uint64_t ts_next_end = std::numeric_limits<uint64_t>::max();
     uint64_t ts_next_beg = ts_next_end - 1;
     auto ev_sync = eudaq::Event::MakeUnique(GetFullName());
     ev_sync->SetTimestamp(m_ts_curr_beg, m_ts_curr_end);

--- a/user/experimental/module/src/TimestampSyncDataCollector.cc
+++ b/user/experimental/module/src/TimestampSyncDataCollector.cc
@@ -3,6 +3,7 @@
 #include <mutex>
 #include <deque>
 #include <map>
+#include <limits>
 
 namespace eudaq {
   class TimestampSyncDataCollector :public DataCollector{
@@ -119,7 +120,7 @@ namespace eudaq {
     }
     
     while(ready_c == m_event_ready.size()){
-      uint64_t ts_next_end = -1;
+      uint64_t ts_next_end = std::numeric_limits<uint64_t>::max();
       uint64_t ts_next_beg = ts_next_end - 1;
       auto ev_wrap = Event::MakeUnique(GetFullName());
       ev_wrap->SetFlagPacket();


### PR DESCRIPTION
Avoid magic conversion of `-1` to the maximum unsigned.

In many places, the code looks as

```
uint32_t trigger_n = -1;
```

This is needed to setup the `trigger_n` as the maximum unsigned representable value. Usually, this is needed to find the minimum trigger id, example

```
if(trigger_n_ev< trigger_n)
	trigger_n = trigger_n_ev;
```

It is not clear as `trigger_n_ev` (unsigned) can be smaller than `-1`. In the code -1 (literal signed) is converted to the maximum `uint32_t`. I hope using `std::numeric_limits<uint32_t>::max()` makes it more clear.