### PR TITLE
Eudet  fix spurious rollovers

### DIFF
--- a/user/eudet/module/src/NiRawEvent2StdEventConverter.cc
+++ b/user/eudet/module/src/NiRawEvent2StdEventConverter.cc
@@ -127,17 +127,19 @@ bool NiRawEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Standar
 
       // if we see a jump and the two conditions are met, correction might have been spurious
       if(abs_difference > 1 && condition_this && condition_previous) {
-        EUDAQ_WARN("            Detected spurious rollover in event: " + std::to_string(d1->GetTriggerN()));
-        EUDAQ_WARN("                                 previous event: " + std::to_string(m_previous_trigger_id));
+        EUDAQ_WARN("Detected spurious rollover in event: " + std::to_string(d1->GetTriggerN()));
+        EUDAQ_WARN("                     previous event: " + std::to_string(m_previous_trigger_id));
         if(m_last_corrected_ID != d1->GetTriggerN()){
           m_spurious_rollovers++;
           // can not keep track of plane ID 
           // need to check if this was already corrected
           m_last_corrected_ID = d1->GetTriggerN();
-          EUDAQ_WARN("                rollover counter incremented to: " + std::to_string(m_spurious_rollovers));
+          EUDAQ_WARN("    rollover counter incremented to: " + std::to_string(m_spurious_rollovers));
+          EUDAQ_WARN("Be weary and check synchonization!");
+
         }
         else{
-          EUDAQ_WARN(" rollover counter already incremented for event: " + std::to_string(m_last_corrected_ID));
+          EUDAQ_WARN("Event already corrected.");
         }
         
         return false;

--- a/user/eudet/module/src/NiRawEvent2StdEventConverter.cc
+++ b/user/eudet/module/src/NiRawEvent2StdEventConverter.cc
@@ -26,7 +26,7 @@ namespace{
 }
 
 bool NiRawEvent2StdEventConverter::m_configured = false;
-bool NiRawEvent2StdEventConverter::m_correct_spurious_rollovers;
+bool NiRawEvent2StdEventConverter::m_correct_spurious_rollovers=false;
 uint64_t NiRawEvent2StdEventConverter::m_previous_trigger_id=0;
 uint64_t NiRawEvent2StdEventConverter::m_spurious_rollovers=0;
 uint64_t NiRawEvent2StdEventConverter::m_last_corrected_ID=0;

--- a/user/eudet/module/src/NiRawEvent2StdEventConverter.cc
+++ b/user/eudet/module/src/NiRawEvent2StdEventConverter.cc
@@ -133,8 +133,10 @@ bool NiRawEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Standar
       // if we see a jump and the two conditions are met, correction might have been spurious
       if(abs_difference > 1 && condition_this && condition_previous) {
         m_spurious_rollovers[id]++;
-        EUDAQ_WARN("Detected spurious rollover in event" + std::to_string(d1->GetTriggerN()));
-        EUDAQ_WARN("   rollover counter incremented to " + std::to_string(m_spurious_rollovers[id]++));
+        EUDAQ_WARN("Detected spurious rollover in event: " + std::to_string(d1->GetTriggerN()));
+        EUDAQ_WARN("                     previous event: " + std::to_string(m_previous_trigger_id[id]));
+        EUDAQ_WARN("    rollover counter incremented to: " + std::to_string(m_spurious_rollovers[id]++));
+        return false;
       }
 
       // revert the spurious rollover correction

--- a/user/eudet/module/src/NiRawEvent2StdEventConverter.cc
+++ b/user/eudet/module/src/NiRawEvent2StdEventConverter.cc
@@ -12,6 +12,12 @@ public:
   void DecodeFrame(eudaq::StandardPlane& plane, const uint32_t fm_n,
            const uint8_t *const d, const size_t l32, bool fix_pivot = false) const;
   static const uint32_t m_id_factory = eudaq::cstr2hash("NiRawDataEvent");
+private:
+  static bool m_configured;
+  static bool m_correct_spurious_rollovers;
+  static std::vector<uint64_t> m_previous_trigger_id;
+  static std::vector<uint64_t> m_spurious_rollovers;
+
 };
 
 namespace{
@@ -19,9 +25,26 @@ namespace{
     Register<NiRawEvent2StdEventConverter>(NiRawEvent2StdEventConverter::m_id_factory);
 }
 
+bool NiRawEvent2StdEventConverter::m_configured = false;
+bool NiRawEvent2StdEventConverter::m_correct_spurious_rollovers;
+std::vector<uint64_t> NiRawEvent2StdEventConverter::m_previous_trigger_id;
+std::vector<uint64_t> NiRawEvent2StdEventConverter::m_spurious_rollovers;
+
 bool NiRawEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::StandardEventSP d2, eudaq::ConfigurationSPC conf) const{
 
   static const std::vector<uint32_t> m_ids = {0, 1, 2, 3, 4, 5};
+
+  if (!m_configured) {
+    m_correct_spurious_rollovers = conf->Get("correct_spurious_rollovers", false);
+    m_spurious_rollovers.reserve(m_ids.size());
+    m_previous_trigger_id.reserve(m_ids.size());
+    for (size_t id = 0; id < m_ids.size(); ++id) {
+      m_spurious_rollovers.push_back(0);
+      m_previous_trigger_id.push_back(0);
+    }
+    m_configured = true;
+  }
+
   //TODO: number of telescope plane may be less than 6. Decode additional tags
   auto ev = std::dynamic_pointer_cast<const eudaq::RawEvent>(d1);
   if(!ev)
@@ -35,7 +58,6 @@ bool NiRawEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Standar
     d2->SetRunN(d1->GetRunN());
     d2->SetEventN(d1->GetEventN());
     d2->SetStreamN(d1->GetStreamN());
-    d2->SetTriggerN(d1->GetTriggerN(), d1->IsFlagTrigger());
     d2->SetTimestamp(d1->GetTimestampBegin(), d1->GetTimestampEnd(), d1->IsFlagTimestamp());
   }
 
@@ -98,6 +120,33 @@ bool NiRawEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Standar
     DecodeFrame(plane, 0, &it0[8], len0, use_all_hits);
     DecodeFrame(plane, 1, &it1[8], len1, use_all_hits);
     d2->AddPlane(plane);
+
+    if(m_correct_spurious_rollovers) {
+
+      // if we are respecting the telescope busy we do not expect jumps in the trigger ID
+      auto abs_difference = std::abs(static_cast<int64_t>(d1->GetTriggerN()) - static_cast<int64_t>(m_previous_trigger_id[id]));
+
+      // these are additional conditions for rollover correction in the Producer
+      bool condition_this = (0x7fff & d1->GetTriggerN()) < 0x2000;
+      bool condition_previous = (0x7fff & m_previous_trigger_id[id]) > 0x6000;
+
+      // if we see a jump and the two conditions are met, correction might have been spurious
+      if(abs_difference > 1 && condition_this && condition_previous) {
+        m_spurious_rollovers[id]++;
+        EUDAQ_WARN("Detected spurious rollover in event" + std::to_string(d1->GetTriggerN()));
+        EUDAQ_WARN("   rollover counter incremented to " + std::to_string(m_spurious_rollovers[id]++));
+      }
+
+      // revert the spurious rollover correction
+      d2->SetTriggerN(d1->GetTriggerN() - (m_spurious_rollovers[id] << 15U), d1->IsFlagTrigger());
+
+      // store trigger ID for next event
+      m_previous_trigger_id[id] = d1->GetTriggerN();
+    }
+    else{
+      // simply get the trigger from data and pass it on
+      d2->SetTriggerN(d1->GetTriggerN(), d1->IsFlagTrigger());
+    }
 
     bool advance_one_block_0 = false;
     bool advance_one_block_1 = false;

--- a/user/eudet/module/src/NiRawEvent2StdEventConverter.cc
+++ b/user/eudet/module/src/NiRawEvent2StdEventConverter.cc
@@ -127,15 +127,19 @@ bool NiRawEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Standar
 
       // if we see a jump and the two conditions are met, correction might have been spurious
       if(abs_difference > 1 && condition_this && condition_previous) {
+        EUDAQ_WARN("            Detected spurious rollover in event: " + std::to_string(d1->GetTriggerN()));
+        EUDAQ_WARN("                                 previous event: " + std::to_string(m_previous_trigger_id));
         if(m_last_corrected_ID != d1->GetTriggerN()){
           m_spurious_rollovers++;
           // can not keep track of plane ID 
           // need to check if this was already corrected
           m_last_corrected_ID = d1->GetTriggerN();
+          EUDAQ_WARN("                rollover counter incremented to: " + std::to_string(m_spurious_rollovers));
         }
-        EUDAQ_WARN("Detected spurious rollover in event: " + std::to_string(d1->GetTriggerN()));
-        EUDAQ_WARN("                     previous event: " + std::to_string(m_previous_trigger_id));
-        EUDAQ_WARN("    rollover counter incremented to: " + std::to_string(m_spurious_rollovers));
+        else{
+          EUDAQ_WARN(" rollover counter already incremented for event: " + std::to_string(m_last_corrected_ID));
+        }
+        
         return false;
       }
 

--- a/user/eudet/module/src/NiRawEvent2StdEventConverter.cc
+++ b/user/eudet/module/src/NiRawEvent2StdEventConverter.cc
@@ -15,9 +15,9 @@ public:
 private:
   static bool m_configured;
   static bool m_correct_spurious_rollovers;
-  static std::vector<uint64_t> m_previous_trigger_id;
-  static std::vector<uint64_t> m_spurious_rollovers;
-
+  static uint64_t m_previous_trigger_id;
+  static uint64_t m_spurious_rollovers;
+  static uint64_t m_last_corrected_ID;
 };
 
 namespace{
@@ -27,8 +27,9 @@ namespace{
 
 bool NiRawEvent2StdEventConverter::m_configured = false;
 bool NiRawEvent2StdEventConverter::m_correct_spurious_rollovers;
-std::vector<uint64_t> NiRawEvent2StdEventConverter::m_previous_trigger_id;
-std::vector<uint64_t> NiRawEvent2StdEventConverter::m_spurious_rollovers;
+uint64_t NiRawEvent2StdEventConverter::m_previous_trigger_id=0;
+uint64_t NiRawEvent2StdEventConverter::m_spurious_rollovers=0;
+uint64_t NiRawEvent2StdEventConverter::m_last_corrected_ID=0;
 
 bool NiRawEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::StandardEventSP d2, eudaq::ConfigurationSPC conf) const{
 
@@ -36,12 +37,6 @@ bool NiRawEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Standar
 
   if (!m_configured) {
     m_correct_spurious_rollovers = conf->Get("correct_spurious_rollovers", false);
-    m_spurious_rollovers.reserve(m_ids.size());
-    m_previous_trigger_id.reserve(m_ids.size());
-    for (size_t id = 0; id < m_ids.size(); ++id) {
-      m_spurious_rollovers.push_back(0);
-      m_previous_trigger_id.push_back(0);
-    }
     m_configured = true;
   }
 
@@ -124,26 +119,31 @@ bool NiRawEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Standar
     if(m_correct_spurious_rollovers) {
 
       // if we are respecting the telescope busy we do not expect jumps in the trigger ID
-      auto abs_difference = std::abs(static_cast<int64_t>(d1->GetTriggerN()) - static_cast<int64_t>(m_previous_trigger_id[id]));
+      auto abs_difference = std::abs(static_cast<int64_t>(d1->GetTriggerN()) - static_cast<int64_t>(m_previous_trigger_id));
 
       // these are additional conditions for rollover correction in the Producer
       bool condition_this = (0x7fff & d1->GetTriggerN()) < 0x2000;
-      bool condition_previous = (0x7fff & m_previous_trigger_id[id]) > 0x6000;
+      bool condition_previous = (0x7fff & m_previous_trigger_id) > 0x6000;
 
       // if we see a jump and the two conditions are met, correction might have been spurious
       if(abs_difference > 1 && condition_this && condition_previous) {
-        m_spurious_rollovers[id]++;
+        if(m_last_corrected_ID != d1->GetTriggerN()){
+          m_spurious_rollovers++;
+          // can not keep track of plane ID 
+          // need to check if this was already corrected
+          m_last_corrected_ID = d1->GetTriggerN();
+        }
         EUDAQ_WARN("Detected spurious rollover in event: " + std::to_string(d1->GetTriggerN()));
-        EUDAQ_WARN("                     previous event: " + std::to_string(m_previous_trigger_id[id]));
-        EUDAQ_WARN("    rollover counter incremented to: " + std::to_string(m_spurious_rollovers[id]++));
+        EUDAQ_WARN("                     previous event: " + std::to_string(m_previous_trigger_id));
+        EUDAQ_WARN("    rollover counter incremented to: " + std::to_string(m_spurious_rollovers));
         return false;
       }
 
       // revert the spurious rollover correction
-      d2->SetTriggerN(d1->GetTriggerN() - (m_spurious_rollovers[id] << 15U), d1->IsFlagTrigger());
+      d2->SetTriggerN(d1->GetTriggerN() - (m_spurious_rollovers << 15U), d1->IsFlagTrigger());
 
       // store trigger ID for next event
-      m_previous_trigger_id[id] = d1->GetTriggerN();
+      m_previous_trigger_id = d1->GetTriggerN();
     }
     else{
       // simply get the trigger from data and pass it on


### PR DESCRIPTION
Fixing spurious trigger counter rollovers caused by faulty trigger IDs in EUDED data.
I did not find a nice way to handle this separately for all planes. Better Ideas?
Tested on data from the ongoing SPARC test beam.